### PR TITLE
player: 修改 AudioQuality 中 HiResLossless 的判断条件

### DIFF
--- a/packages/player/src/components/LocalMusicContext/index.tsx
+++ b/packages/player/src/components/LocalMusicContext/index.tsx
@@ -813,7 +813,7 @@ function processAudioQuality(
 		const sampleRate = definiteQuality.sampleRate;
 		const bitsPerSample = definiteQuality.bitsPerSample;
 
-		if (sampleRate > 44100 || bitsPerSample > 16) {
+		if (sampleRate >= 96000 || bitsPerSample >= 24) {
 			return {
 				...definiteQuality,
 				type: AudioQualityType.HiResLossless,


### PR DESCRIPTION
将 HiRes Lossless 的判断条件由 16bit 44100Hz 提升为 24bit 96000Hz。