### PR TITLE
player: 优化 AudioQuality 中 HiResLossless 的判断条件

### DIFF
--- a/packages/player/src/components/LocalMusicContext/index.tsx
+++ b/packages/player/src/components/LocalMusicContext/index.tsx
@@ -834,7 +834,7 @@ function processAudioQuality(
 		const sampleRate = definiteQuality.sampleRate;
 		const bitsPerSample = definiteQuality.bitsPerSample;
 
-		if (sampleRate >= 96000 || bitsPerSample >= 24) {
+		if (sampleRate >= 96000 && bitsPerSample >= 24) {
 			return {
 				...definiteQuality,
 				type: AudioQualityType.HiResLossless,


### PR DESCRIPTION
把之前 ”24bit与96kHz满足其一就展示HiResLossless“ 的逻辑修正为 ”需要同时满足24bit与96kHz才展示HiResLossless“ 。