### PR TITLE
player_core: 修复 EmptyMediaStateManager 导致的热循环

### DIFF
--- a/packages/player-core/src/player.rs
+++ b/packages/player-core/src/player.rs
@@ -316,6 +316,8 @@ impl AudioPlayer {
                 msg = media_state_fut => {
                     if let Some(msg) = msg {
                         self.on_media_state_msg(msg).await;
+                    } else {
+                        self.media_state_rx = None;
                     }
                 }
                 evt = self.evt_receiver.recv() => {


### PR DESCRIPTION
在除了 Windows 和 macOS 的平台上，媒体控件都是空实现，导致 select! 循环在 media_state_fut 分支上空转，饿死了所有其他分支

Linux 版本现在应该可以正常使用了，安卓版本的性能应该会有改善（虽然它现在还是没法添加文件）