### PR TITLE
core: 对唱歌词的逐词音译与主歌词左对齐

### DIFF
--- a/packages/core/src/styles/lyric-player.module.css
+++ b/packages/core/src/styles/lyric-player.module.css
@@ -102,6 +102,7 @@
 
 	& span {
 		display: inline-block;
+        text-align: start;
 	}
 	
 	.romanWord {


### PR DESCRIPTION
目前只是简单实现了左对齐；

对唱部分的逐词音译长度超出主歌词长度后主歌词没有与对唱歌词左对齐（还在想办法调）。

<img width="2560" height="1390" alt="image" src="https://github.com/user-attachments/assets/8fd3fec4-533d-4168-861f-d17d1e88744b" />