### PR TITLE
feat(窗口): 添加窗口置顶功能

### DIFF
--- a/packages/player/src-tauri/src/lib.rs
+++ b/packages/player/src-tauri/src/lib.rs
@@ -64,6 +64,26 @@ fn restart_app<R: Runtime>(app: AppHandle<R>) {
     tauri::process::restart(&app.env())
 }
 
+#[tauri::command]
+fn set_window_always_on_top<R: Runtime>(
+    enabled: bool,
+    app: AppHandle<R>,
+) -> Result<(), String> {
+    #[cfg(target_os = "windows")]
+    {
+        if let Some(window) = app.get_webview_window("main") {
+            window.set_always_on_top(enabled).map_err(|e| e.to_string())
+        } else {
+            Err("Main window not found.".to_string())
+        }
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        let _ = (enabled, app);
+        Err("Unsupported on this platform.".to_string())
+    }
+}
+
 #[derive(Default, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MusicInfo {
@@ -406,6 +426,8 @@ pub fn run() {
             resolve_content_uri,
             read_local_music_metadata,
             restart_app,
+            #[cfg(target_os = "windows")]
+            set_window_always_on_top,
             #[cfg(target_os = "windows")]
             taskbar_lyric::mouse_forward::set_click_interception,
             #[cfg(target_os = "windows")]

--- a/packages/player/src/components/AMLLContextMenu/index.tsx
+++ b/packages/player/src/components/AMLLContextMenu/index.tsx
@@ -13,10 +13,11 @@ import { useAtom, useAtomValue, useSetAtom } from "jotai";
 import type { FC } from "react";
 import { Trans } from "react-i18next";
 import { router } from "../../router.tsx";
-import { recordPanelOpenedAtom } from "../../states/appAtoms.ts";
+import { enableAlwaysOnTopAtom, recordPanelOpenedAtom } from "../../states/appAtoms.ts";
 
 export const AMLLContextMenuContent: FC = () => {
 	const [hideLyricView, setHideLyricView] = useAtom(hideLyricViewAtom);
+	const [alwaysOnTop, setAlwaysOnTop] = useAtom(enableAlwaysOnTopAtom);
 	const setLyricPageOpened = useSetAtom(isLyricPageOpenedAtom);
 	const setRecordPanelOpened = useSetAtom(recordPanelOpenedAtom);
 	const onRequestPrevSong = useAtomValue(onRequestPrevSongAtom).onEmit;
@@ -48,6 +49,12 @@ export const AMLLContextMenuContent: FC = () => {
 					全屏 / 取消全屏
 				</Trans>
 			</ContextMenu.Item>
+			<ContextMenu.CheckboxItem
+				checked={alwaysOnTop}
+				onCheckedChange={(e) => setAlwaysOnTop(!!e)}
+			>
+				<Trans i18nKey="amll.contextMenu.windowAlwaysOnTop">窗口置顶</Trans>
+			</ContextMenu.CheckboxItem>
 			<ContextMenu.Separator />
 			<ContextMenu.CheckboxItem
 				checked={!hideLyricView}

--- a/packages/player/src/pages/settings/player.tsx
+++ b/packages/player/src/pages/settings/player.tsx
@@ -56,6 +56,7 @@ import {
 } from "@radix-ui/themes";
 import { getVersion } from "@tauri-apps/api/app";
 import { invoke } from "@tauri-apps/api/core";
+import { platform } from "@tauri-apps/plugin-os";
 import { atom, useAtom, useAtomValue, type WritableAtom } from "jotai";
 import { loadable } from "jotai/utils";
 import React, {
@@ -63,6 +64,7 @@ import React, {
 	type PropsWithChildren,
 	type ReactNode,
 	Suspense,
+	useEffect,
 	useLayoutEffect,
 	useMemo,
 	useState,
@@ -76,6 +78,7 @@ import {
 	bottomLyricDisplayModeAtom,
 	DarkMode,
 	darkModeAtom,
+	enableAlwaysOnTopAtom,
 	enableMediaControlsAtom,
 	enableTaskbarLyricAtom,
 	showStatJSFrameAtom,
@@ -303,6 +306,11 @@ function SliderSettings<T extends number | number[]>({
 const GeneralSettings = () => {
 	const { t, i18n } = useTranslation();
 	const [mode, setMode] = useAtom(darkModeAtom);
+	const [os, setOs] = useState<string | null>(null);
+
+	useEffect(() => {
+		setOs(platform());
+	}, []);
 
 	const supportedLanguagesMenu = useMemo(() => {
 		function collectLocaleKey(
@@ -409,6 +417,19 @@ const GeneralSettings = () => {
 					</Select.Content>
 				</Select.Root>
 			</SettingEntry>
+			{os === "windows" && (
+				<SwitchSettings
+					label={t(
+						"page.settings.general.windowAlwaysOnTop.label",
+						"启用窗口置顶",
+					)}
+					description={t(
+						"page.settings.general.windowAlwaysOnTop.description",
+						"将应用窗口设置为始终置顶",
+					)}
+					configAtom={enableAlwaysOnTopAtom}
+				/>
+			)}
 		</>
 	);
 };

--- a/packages/player/src/states/appAtoms.ts
+++ b/packages/player/src/states/appAtoms.ts
@@ -59,6 +59,21 @@ export const enableMediaControlsAtom = atom(
 	},
 );
 
+const enableAlwaysOnTopInternalAtom = atomWithStorage(
+	"amll-player.enableAlwaysOnTop",
+	false,
+);
+
+export const enableAlwaysOnTopAtom = atom(
+	(get) => get(enableAlwaysOnTopInternalAtom),
+	(_get, set, enabled: boolean) => {
+		set(enableAlwaysOnTopInternalAtom, enabled);
+		invoke("set_window_always_on_top", { enabled }).catch((err) => {
+			console.error("设置窗口置顶状态失败", err);
+		});
+	},
+);
+
 export const wsProtocolListenAddrAtom = atomWithStorage(
 	"amll-player.wsProtocolListenAddr",
 	"localhost:11444",

--- a/packages/player/src/utils/useInitializeWindow.ts
+++ b/packages/player/src/utils/useInitializeWindow.ts
@@ -1,4 +1,5 @@
 import { getCurrentWindow } from "@tauri-apps/api/window";
+import { invoke } from "@tauri-apps/api/core";
 import { platform, version } from "@tauri-apps/plugin-os";
 import { useStore } from "jotai";
 import { useEffect, useRef } from "react";
@@ -15,19 +16,26 @@ export const useInitializeWindow = () => {
 			isInitializedRef.current = true;
 
 			setTimeout(async () => {
-				try {
-					const appWindow = getCurrentWindow();
+			try {
+				const appWindow = getCurrentWindow();
 
-					if (platform() === "windows" && !semverGt(version(), "10.0.22000")) {
-						store.set(hasBackgroundAtom, true);
-						await appWindow.clearEffects();
-					}
-
-					await appWindow.show();
-				} catch (err) {
-					console.error("初始化窗口失败:", err);
+				if (platform() === "windows" && !semverGt(version(), "10.0.22000")) {
+					store.set(hasBackgroundAtom, true);
+					await appWindow.clearEffects();
 				}
-			}, 50);
+
+				if (platform() === "windows") {
+					const enabled = localStorage.getItem("amll-player.enableAlwaysOnTop") === "true";
+					invoke("set_window_always_on_top", { enabled }).catch((err) => {
+						console.error("同步窗口置顶状态失败", err);
+					});
+				}
+
+				await appWindow.show();
+			} catch (err) {
+				console.error("初始化窗口失败:", err);
+			}
+		}, 50);
 		};
 
 		initializeWindow();


### PR DESCRIPTION
实现窗口置顶功能，允许用户将播放器窗口保持在所有窗口最前端。

## 细节
- ✅ 添加 Tauri 后端命令处理窗口置顶状态
- ✅ 使用 Jotai 原子状态管理，支持持久化存储
- ✅ 右键菜单添加快捷切换选项
- ✅ 设置页面添加控制开关
- ✅ 应用启动时自动同步置顶状态

## 测试要点
- [x] 右键菜单可以切换置顶状态
- [x] 设置页面可以切换置顶状态
- [x] 重启应用后置顶状态保持
- [x] 仅在 Windows 平台生效
- [x] 已在github测试预编译成功
https://github.com/Shomi-FJS/applemusic-like-lyrics/actions/runs/23928170919/job/69789412290
## 相关文件
- packages/player/src-tauri/src/lib.rs
- packages/player/src/states/appAtoms.ts
- packages/player/src/components/AMLLContextMenu/index.tsx
- packages/player/src/pages/settings/player.tsx
- packages/player/src/utils/useInitializeWindow.ts

<img width="1765" height="1172" alt="屏幕截图 2026-04-03 084013" src="https://github.com/user-attachments/assets/a75227af-3192-4dcd-90a0-33f8c0b0f8e8" />
<img width="1760" height="1155" alt="屏幕截图 2026-04-03 084032" src="https://github.com/user-attachments/assets/3f348f6d-8f9c-4ca4-b0fa-cdb0d9722979" />
