### PR TITLE
fix(core): 默认关闭 cleanUnintentionalOverlaps

### DIFF
--- a/.nx/version-plans/version-plan-1776115200000.md
+++ b/.nx/version-plans/version-plan-1776115200000.md
@@ -1,0 +1,5 @@
+---
+core-bundle: patch
+---
+
+fix(core): 默认关闭 optimizeLyricLines 的 cleanUnintentionalOverlaps，避免误截断相邻歌词行。需要旧行为时请显式传入 `cleanUnintentionalOverlaps: true`。

--- a/packages/core/src/interfaces.ts
+++ b/packages/core/src/interfaces.ts
@@ -98,7 +98,7 @@ export interface OptimizeLyricOptions {
 	 * * 重叠时长不足下一行时长的 10%
 	 *
 	 * 则截断上一行歌词的结束时间为下一行歌词的开始时间
-	 * @default true
+	 * @default false
 	 */
 	cleanUnintentionalOverlaps?: boolean;
 	/**

--- a/packages/core/src/utils/optimize-lyric.ts
+++ b/packages/core/src/utils/optimize-lyric.ts
@@ -5,7 +5,7 @@ const DEFAULT_OPTIMIZE_OPTIONS: OptimizeLyricOptions = {
 	resetLineTimestamps: true,
 	convertExcessiveBackgroundLines: true,
 	syncMainAndBackgroundLines: true,
-	cleanUnintentionalOverlaps: true,
+	cleanUnintentionalOverlaps: false,
 	tryAdvanceStartTime: true,
 };
 


### PR DESCRIPTION
把甩尾行为默认关闭，因不成熟