### PR TITLE
ci: 修复发布工作流编排错误

### DIFF
--- a/.github/workflows/publish-libs.yaml
+++ b/.github/workflows/publish-libs.yaml
@@ -92,4 +92,4 @@ jobs:
 
       - name: Publish packages to npm
         if: github.event.inputs.mode == 'publish'
-        run: npx nx release publish
+        run: npx nx release publish --excludeTaskDependencies

--- a/.nx/version-plans/version-plan-1776185929059.md
+++ b/.nx/version-plans/version-plan-1776185929059.md
@@ -1,0 +1,5 @@
+---
+'@applemusic-like-lyrics/react-full': patch
+---
+
+ci: 修复工作流错误导致的不成功发布


### PR DESCRIPTION
添加 --excludeTaskDependencies 标志