### PR TITLE
ci: 调整 changelog 格式与若干 CI 行为

### DIFF
--- a/.github/workflows/deploy-site.yaml
+++ b/.github/workflows/deploy-site.yaml
@@ -1,4 +1,5 @@
 name: "Deploy site"
+run-name: "Deploy site - ${{ github.event.head_commit.message || 'manual dispatch' }}"
 
 on:
   push:

--- a/.github/workflows/pr-release-check.yaml
+++ b/.github/workflows/pr-release-check.yaml
@@ -35,6 +35,11 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+
       - name: Decide whether a release plan is required
         id: release-requirements
         run: bun .github/scripts/check-release-requirements.mjs

--- a/.github/workflows/pr-release-check.yaml
+++ b/.github/workflows/pr-release-check.yaml
@@ -1,4 +1,5 @@
 name: Validate PR
+run-name: Validate PR #${{ github.event.pull_request.number }} - ${{ github.event.pull_request.title }}
 
 on:
   pull_request:

--- a/.github/workflows/pr-release-check.yaml
+++ b/.github/workflows/pr-release-check.yaml
@@ -1,5 +1,5 @@
 name: Validate PR
-run-name: Validate PR #${{ github.event.pull_request.number }} - ${{ github.event.pull_request.title }}
+run-name: "Validate PR #${{ github.event.pull_request.number }} - ${{ github.event.pull_request.title }}"
 
 on:
   pull_request:

--- a/.github/workflows/pr-release-check.yaml
+++ b/.github/workflows/pr-release-check.yaml
@@ -35,11 +35,6 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: "24"
-
       - name: Decide whether a release plan is required
         id: release-requirements
         run: bun .github/scripts/check-release-requirements.mjs
@@ -77,6 +72,11 @@ jobs:
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.nx/scripts/changelog-render.ts
+++ b/.nx/scripts/changelog-render.ts
@@ -99,11 +99,17 @@ export default class CustomChangelogRenderer extends DefaultChangelogRenderer {
 
 	private sortChangesByPrefix(changes: ChangelogChange[]): ChangelogChange[] {
 		const prefixOrder = new Map<string, number>([
-			["fix", 0],
-			["feat", 1],
-			["chore", 2],
-			["docs", 100],
-			["ci", 101],
+			["feat", 0],
+			["fix", 1],
+			["perf", 2],
+			["refactor", 3],
+			["docs", 4],
+			["chore", 5],
+			["ci", 6],
+			["test", 7],
+			["build", 8],
+			["style", 9],
+			["revert", 10],
 		]);
 
 		return [...changes].sort((a, b) => {

--- a/.nx/scripts/changelog-render.ts
+++ b/.nx/scripts/changelog-render.ts
@@ -1,0 +1,123 @@
+import DefaultChangelogRenderer, {
+	type ChangelogChange,
+} from "nx/release/changelog-renderer";
+
+export default class CustomChangelogRenderer extends DefaultChangelogRenderer {
+	protected renderChangesByType(): string[] {
+		const markdownLines: string[] = [];
+		const groups = this.groupChangesBySemverImpact();
+
+		this.appendChangeGroup(markdownLines, "Major Changes", groups.major);
+		this.appendChangeGroup(markdownLines, "Minor Changes", groups.minor);
+		this.appendChangeGroup(markdownLines, "Patch Changes", groups.patch);
+
+		return markdownLines;
+	}
+
+	protected renderDependencyBumps(): string[] {
+		const markdownLines = ["", "### Updated Dependencies", ""];
+		this.dependencyBumps?.forEach(({ dependencyName, newVersion }) => {
+			markdownLines.push(
+				`- Updated \`${dependencyName}\` to \`${newVersion}\``,
+			);
+		});
+		return markdownLines;
+	}
+
+	protected async renderAuthors(): Promise<string[]> {
+		const markdownLines = await super.renderAuthors();
+		return markdownLines.map((line) => {
+			if (line === "### ❤️ Thank You") return "### Contributors";
+			if (!line.startsWith("- ")) return line;
+			const authorPattern = /- (.+) @(.+)$/;
+			return line.replace(
+				authorPattern,
+				(_, name: string, username: string) =>
+					`- ${name} [@${username}](https://github.com/${username})`,
+			);
+		});
+	}
+
+	protected formatChange(change: ChangelogChange): string {
+		const line = super.formatChange(change);
+		return this.boldConventionalTagInLine(line);
+	}
+
+	async render(): Promise<string> {
+		return super.render();
+	}
+
+	private groupChangesBySemverImpact(): {
+		major: ChangelogChange[];
+		minor: ChangelogChange[];
+		patch: ChangelogChange[];
+	} {
+		const major: ChangelogChange[] = [];
+		const minor: ChangelogChange[] = [];
+		const patch: ChangelogChange[] = [];
+
+		for (const change of this.relevantChanges) {
+			if (change.isBreaking) {
+				major.push(change);
+				continue;
+			}
+			if (change.type === "feat") {
+				minor.push(change);
+				continue;
+			}
+			patch.push(change);
+		}
+
+		return { major, minor, patch };
+	}
+
+	private appendChangeGroup(
+		lines: string[],
+		title: string,
+		group: ChangelogChange[],
+	): void {
+		if (group.length === 0) {
+			return;
+		}
+
+		const sortedGroup = this.sortChangesByPrefix(group);
+		lines.push("", `### ${title}`, "");
+		for (const change of sortedGroup) {
+			lines.push(this.formatChange(change));
+		}
+	}
+
+	private boldConventionalTagInLine(line: string): string {
+		const conventionalTagPattern =
+			/^(-\s+(?:\*\*[^*]+:\*\*\s+)?)([a-z]+(?:\([^)]+\))?:)(\s+)/i;
+		return line.replace(
+			conventionalTagPattern,
+			(_, prefix: string, tag: string, suffix: string) =>
+				`${prefix}**${tag}**${suffix}`,
+		);
+	}
+
+	private sortChangesByPrefix(changes: ChangelogChange[]): ChangelogChange[] {
+		const prefixOrder = new Map<string, number>([
+			["fix", 0],
+			["feat", 1],
+			["chore", 2],
+			["docs", 100],
+			["ci", 101],
+		]);
+
+		return [...changes].sort((a, b) => {
+			const aPrefix = this.getConventionalPrefix(a.description ?? "");
+			const bPrefix = this.getConventionalPrefix(b.description ?? "");
+			const aRank = prefixOrder.get(aPrefix) ?? 99;
+			const bRank = prefixOrder.get(bPrefix) ?? 99;
+			if (aRank !== bRank) return aRank - bRank;
+			return 0;
+		});
+	}
+
+	private getConventionalPrefix(description: string): string {
+		const match = description.match(/^([a-z]+)(?:\([^)]+\))?:\s+/i);
+		return match?.[1].toLowerCase() ?? "";
+	}
+}

--- a/bun.lock
+++ b/bun.lock
@@ -11,6 +11,7 @@
         "@typescript/native-preview": "^7.0.0-dev.20260412.1",
         "npm-run-all2": "^8.0.4",
         "nx": "^22.6.0",
+        "swc-node": "^1.0.0",
         "tsdown": "catalog:",
       },
     },
@@ -752,6 +753,46 @@
 
     "@oxc-project/types": ["@oxc-project/types@0.122.0", "", {}, "sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA=="],
 
+    "@oxc-resolver/binding-android-arm-eabi": ["@oxc-resolver/binding-android-arm-eabi@11.19.1", "", { "os": "android", "cpu": "arm" }, "sha512-aUs47y+xyXHUKlbhqHUjBABjvycq6YSD7bpxSW7vplUmdzAlJ93yXY6ZR0c1o1x5A/QKbENCvs3+NlY8IpIVzg=="],
+
+    "@oxc-resolver/binding-android-arm64": ["@oxc-resolver/binding-android-arm64@11.19.1", "", { "os": "android", "cpu": "arm64" }, "sha512-oolbkRX+m7Pq2LNjr/kKgYeC7bRDMVTWPgxBGMjSpZi/+UskVo4jsMU3MLheZV55jL6c3rNelPl4oD60ggYmqA=="],
+
+    "@oxc-resolver/binding-darwin-arm64": ["@oxc-resolver/binding-darwin-arm64@11.19.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-nUC6d2i3R5B12sUW4O646qD5cnMXf2oBGPLIIeaRfU9doJRORAbE2SGv4eW6rMqhD+G7nf2Y8TTJTLiiO3Q/dQ=="],
+
+    "@oxc-resolver/binding-darwin-x64": ["@oxc-resolver/binding-darwin-x64@11.19.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-cV50vE5+uAgNcFa3QY1JOeKDSkM/9ReIcc/9wn4TavhW/itkDGrXhw9jaKnkQnGbjJ198Yh5nbX/Gr2mr4Z5jQ=="],
+
+    "@oxc-resolver/binding-freebsd-x64": ["@oxc-resolver/binding-freebsd-x64@11.19.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-xZOQiYGFxtk48PBKff+Zwoym7ScPAIVp4c14lfLxizO2LTTTJe5sx9vQNGrBymrf/vatSPNMD4FgsaaRigPkqw=="],
+
+    "@oxc-resolver/binding-linux-arm-gnueabihf": ["@oxc-resolver/binding-linux-arm-gnueabihf@11.19.1", "", { "os": "linux", "cpu": "arm" }, "sha512-lXZYWAC6kaGe/ky2su94e9jN9t6M0/6c+GrSlCqL//XO1cxi5lpAhnJYdyrKfm0ZEr/c7RNyAx3P7FSBcBd5+A=="],
+
+    "@oxc-resolver/binding-linux-arm-musleabihf": ["@oxc-resolver/binding-linux-arm-musleabihf@11.19.1", "", { "os": "linux", "cpu": "arm" }, "sha512-veG1kKsuK5+t2IsO9q0DErYVSw2azvCVvWHnfTOS73WE0STdLLB7Q1bB9WR+yHPQM76ASkFyRbogWo1GR1+WbQ=="],
+
+    "@oxc-resolver/binding-linux-arm64-gnu": ["@oxc-resolver/binding-linux-arm64-gnu@11.19.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-heV2+jmXyYnUrpUXSPugqWDRpnsQcDm2AX4wzTuvgdlZfoNYO0O3W2AVpJYaDn9AG4JdM6Kxom8+foE7/BcSig=="],
+
+    "@oxc-resolver/binding-linux-arm64-musl": ["@oxc-resolver/binding-linux-arm64-musl@11.19.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-jvo2Pjs1c9KPxMuMPIeQsgu0mOJF9rEb3y3TdpsrqwxRM+AN6/nDDwv45n5ZrUnQMsdBy5gIabioMKnQfWo9ew=="],
+
+    "@oxc-resolver/binding-linux-ppc64-gnu": ["@oxc-resolver/binding-linux-ppc64-gnu@11.19.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-vLmdNxWCdN7Uo5suays6A/+ywBby2PWBBPXctWPg5V0+eVuzsJxgAn6MMB4mPlshskYbppjpN2Zg83ArHze9gQ=="],
+
+    "@oxc-resolver/binding-linux-riscv64-gnu": ["@oxc-resolver/binding-linux-riscv64-gnu@11.19.1", "", { "os": "linux", "cpu": "none" }, "sha512-/b+WgR+VTSBxzgOhDO7TlMXC1ufPIMR6Vj1zN+/x+MnyXGW7prTLzU9eW85Aj7Th7CCEG9ArCbTeqxCzFWdg2w=="],
+
+    "@oxc-resolver/binding-linux-riscv64-musl": ["@oxc-resolver/binding-linux-riscv64-musl@11.19.1", "", { "os": "linux", "cpu": "none" }, "sha512-YlRdeWb9j42p29ROh+h4eg/OQ3dTJlpHSa+84pUM9+p6i3djtPz1q55yLJhgW9XfDch7FN1pQ/Vd6YP+xfRIuw=="],
+
+    "@oxc-resolver/binding-linux-s390x-gnu": ["@oxc-resolver/binding-linux-s390x-gnu@11.19.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-EDpafVOQWF8/MJynsjOGFThcqhRHy417sRyLfQmeiamJ8qVhSKAn2Dn2VVKUGCjVB9C46VGjhNo7nOPUi1x6uA=="],
+
+    "@oxc-resolver/binding-linux-x64-gnu": ["@oxc-resolver/binding-linux-x64-gnu@11.19.1", "", { "os": "linux", "cpu": "x64" }, "sha512-NxjZe+rqWhr+RT8/Ik+5ptA3oz7tUw361Wa5RWQXKnfqwSSHdHyrw6IdcTfYuml9dM856AlKWZIUXDmA9kkiBQ=="],
+
+    "@oxc-resolver/binding-linux-x64-musl": ["@oxc-resolver/binding-linux-x64-musl@11.19.1", "", { "os": "linux", "cpu": "x64" }, "sha512-cM/hQwsO3ReJg5kR+SpI69DMfvNCp+A/eVR4b4YClE5bVZwz8rh2Nh05InhwI5HR/9cArbEkzMjcKgTHS6UaNw=="],
+
+    "@oxc-resolver/binding-openharmony-arm64": ["@oxc-resolver/binding-openharmony-arm64@11.19.1", "", { "os": "none", "cpu": "arm64" }, "sha512-QF080IowFB0+9Rh6RcD19bdgh49BpQHUW5TajG1qvWHvmrQznTZZjYlgE2ltLXyKY+qs4F/v5xuX1XS7Is+3qA=="],
+
+    "@oxc-resolver/binding-wasm32-wasi": ["@oxc-resolver/binding-wasm32-wasi@11.19.1", "", { "dependencies": { "@napi-rs/wasm-runtime": "^1.1.1" }, "cpu": "none" }, "sha512-w8UCKhX826cP/ZLokXDS6+milN8y4X7zidsAttEdWlVoamTNf6lhBJldaWr3ukTDiye7s4HRcuPEPOXNC432Vg=="],
+
+    "@oxc-resolver/binding-win32-arm64-msvc": ["@oxc-resolver/binding-win32-arm64-msvc@11.19.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-nJ4AsUVZrVKwnU/QRdzPCCrO0TrabBqgJ8pJhXITdZGYOV28TIYystV1VFLbQ7DtAcaBHpocT5/ZJnF78YJPtQ=="],
+
+    "@oxc-resolver/binding-win32-ia32-msvc": ["@oxc-resolver/binding-win32-ia32-msvc@11.19.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-EW+ND5q2Tl+a3pH81l1QbfgbF3HmqgwLfDfVithRFheac8OTcnbXt/JxqD2GbDkb7xYEqy1zNaVFRr3oeG8npA=="],
+
+    "@oxc-resolver/binding-win32-x64-msvc": ["@oxc-resolver/binding-win32-x64-msvc@11.19.1", "", { "os": "win32", "cpu": "x64" }, "sha512-6hIU3RQu45B+VNTY4Ru8ppFwjVS/S5qwYyGhBotmjxfEKk41I2DlGtRfGJndZ5+6lneE2pwloqunlOyZuX/XAw=="],
+
     "@pagefind/darwin-arm64": ["@pagefind/darwin-arm64@1.5.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-MXpI+7HsAdPkvJ0gk9xj9g541BCqBZOBbdwj9g6lB5LCj6kSV6nqDSjzcAJwvOsfu0fjwvC8hQU+ecfhp+MpiQ=="],
 
     "@pagefind/darwin-x64": ["@pagefind/darwin-x64@1.5.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-IojxFWMEJe0RQ7PQ3KXQsPIImNsbpPYpoZ+QUDrL8fAl/O27IX+LVLs74/UzEZy5uA2LD8Nz1AiwKr72vrkZQw=="],
@@ -1054,6 +1095,12 @@
 
     "@svgr/plugin-jsx": ["@svgr/plugin-jsx@8.1.0", "", { "dependencies": { "@babel/core": "^7.21.3", "@svgr/babel-preset": "8.1.0", "@svgr/hast-util-to-babel-ast": "8.0.0", "svg-parser": "^2.0.4" }, "peerDependencies": { "@svgr/core": "*" } }, "sha512-0xiIyBsLlr8quN+WyuxooNW9RJ0Dpr8uOnH/xrCVO8GLUcwHISwj1AG0k+LFzteTkAA0GbX0kj9q6Dk70PTiPA=="],
 
+    "@swc-node/core": ["@swc-node/core@1.14.1", "", { "peerDependencies": { "@swc/core": ">= 1.13.3", "@swc/types": ">= 0.1" } }, "sha512-jrt5GUaZUU6cmMS+WTJEvGvaB6j1YNKPHPzC2PUi2BjaFbtxURHj6641Az6xN7b665hNniAIdvjxWcRml5yCnw=="],
+
+    "@swc-node/register": ["@swc-node/register@1.11.1", "", { "dependencies": { "@swc-node/core": "^1.14.1", "@swc-node/sourcemap-support": "^0.6.1", "colorette": "^2.0.20", "debug": "^4.4.1", "oxc-resolver": "^11.6.1", "pirates": "^4.0.7", "tslib": "^2.8.1" }, "peerDependencies": { "@swc/core": ">= 1.4.13", "typescript": ">= 4.3" } }, "sha512-VQ0hJ5jX31TVv/fhZx4xJRzd8pwn6VvzYd2tGOHHr2TfXGCBixZoqdPDXTiEoJLCTS2MmvBf6zyQZZ0M8aGQCQ=="],
+
+    "@swc-node/sourcemap-support": ["@swc-node/sourcemap-support@0.6.1", "", { "dependencies": { "source-map-support": "^0.5.21", "tslib": "^2.8.1" } }, "sha512-ovltDVH5QpdHXZkW138vG4+dgcNsxfwxHVoV6BtmTbz2KKl1A8ZSlbdtxzzfNjCjbpayda8Us9eMtcHobm38dA=="],
+
     "@swc/core": ["@swc/core@1.15.24", "", { "dependencies": { "@swc/counter": "^0.1.3", "@swc/types": "^0.1.26" }, "optionalDependencies": { "@swc/core-darwin-arm64": "1.15.24", "@swc/core-darwin-x64": "1.15.24", "@swc/core-linux-arm-gnueabihf": "1.15.24", "@swc/core-linux-arm64-gnu": "1.15.24", "@swc/core-linux-arm64-musl": "1.15.24", "@swc/core-linux-ppc64-gnu": "1.15.24", "@swc/core-linux-s390x-gnu": "1.15.24", "@swc/core-linux-x64-gnu": "1.15.24", "@swc/core-linux-x64-musl": "1.15.24", "@swc/core-win32-arm64-msvc": "1.15.24", "@swc/core-win32-ia32-msvc": "1.15.24", "@swc/core-win32-x64-msvc": "1.15.24" }, "peerDependencies": { "@swc/helpers": ">=0.5.17" }, "optionalPeers": ["@swc/helpers"] }, "sha512-5Hj8aNasue7yusUt8LGCUe/AjM7RMAce8ZoyDyiFwx7Al+GbYKL+yE7g4sJk8vEr1dKIkTRARkNIJENc4CjkBQ=="],
 
     "@swc/core-darwin-arm64": ["@swc/core-darwin-arm64@1.15.24", "", { "os": "darwin", "cpu": "arm64" }, "sha512-uM5ZGfFXjtvtJ+fe448PVBEbn/CSxS3UAyLj3O9xOqKIWy3S6hPTXSPbszxkSsGDYKi+YFhzAsR4r/eXLxEQ0g=="],
@@ -1331,6 +1378,8 @@
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
+    "colorette": ["colorette@2.0.20", "", {}, "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="],
 
     "columnify": ["columnify@1.6.0", "", { "dependencies": { "strip-ansi": "^6.0.1", "wcwidth": "^1.0.0" } }, "sha512-lomjuFZKfM6MSAnV9aCZC9sc0qGbmZdfygNv+nCpqVkSKdCxCklLtd16O0EILGkImHw9ZpHkAnHaB+8Zxq5W6Q=="],
 
@@ -1902,6 +1951,8 @@
 
     "ora": ["ora@5.3.0", "", { "dependencies": { "bl": "^4.0.3", "chalk": "^4.1.0", "cli-cursor": "^3.1.0", "cli-spinners": "^2.5.0", "is-interactive": "^1.0.0", "log-symbols": "^4.0.0", "strip-ansi": "^6.0.0", "wcwidth": "^1.0.1" } }, "sha512-zAKMgGXUim0Jyd6CXK9lraBnD3H5yPGBPPOkC23a2BG6hsm4Zu6OQSjQuEtV0BHDf4aKHcUFvJiGRrFuW3MG8g=="],
 
+    "oxc-resolver": ["oxc-resolver@11.19.1", "", { "optionalDependencies": { "@oxc-resolver/binding-android-arm-eabi": "11.19.1", "@oxc-resolver/binding-android-arm64": "11.19.1", "@oxc-resolver/binding-darwin-arm64": "11.19.1", "@oxc-resolver/binding-darwin-x64": "11.19.1", "@oxc-resolver/binding-freebsd-x64": "11.19.1", "@oxc-resolver/binding-linux-arm-gnueabihf": "11.19.1", "@oxc-resolver/binding-linux-arm-musleabihf": "11.19.1", "@oxc-resolver/binding-linux-arm64-gnu": "11.19.1", "@oxc-resolver/binding-linux-arm64-musl": "11.19.1", "@oxc-resolver/binding-linux-ppc64-gnu": "11.19.1", "@oxc-resolver/binding-linux-riscv64-gnu": "11.19.1", "@oxc-resolver/binding-linux-riscv64-musl": "11.19.1", "@oxc-resolver/binding-linux-s390x-gnu": "11.19.1", "@oxc-resolver/binding-linux-x64-gnu": "11.19.1", "@oxc-resolver/binding-linux-x64-musl": "11.19.1", "@oxc-resolver/binding-openharmony-arm64": "11.19.1", "@oxc-resolver/binding-wasm32-wasi": "11.19.1", "@oxc-resolver/binding-win32-arm64-msvc": "11.19.1", "@oxc-resolver/binding-win32-ia32-msvc": "11.19.1", "@oxc-resolver/binding-win32-x64-msvc": "11.19.1" } }, "sha512-qE/CIg/spwrTBFt5aKmwe3ifeDdLfA2NESN30E42X/lII5ClF8V7Wt6WIJhcGZjp0/Q+nQ+9vgxGk//xZNX2hg=="],
+
     "p-limit": ["p-limit@7.3.0", "", { "dependencies": { "yocto-queue": "^1.2.1" } }, "sha512-7cIXg/Z0M5WZRblrsOla88S4wAK+zOQQWeBYfV3qJuJXMr+LnbYjaadrFaS0JILfEDPVqHyKnZ1Z/1d6J9VVUw=="],
 
     "p-queue": ["p-queue@9.1.2", "", { "dependencies": { "eventemitter3": "^5.0.1", "p-timeout": "^7.0.0" } }, "sha512-ktsDOALzTYTWWF1PbkNVg2rOt+HaOaMWJMUnt7T3qf5tvZ1L8dBW3tObzprBcXNMKkwj+yFSLqHso0x+UFcJXw=="],
@@ -1939,6 +1990,8 @@
     "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
     "pidtree": ["pidtree@0.6.0", "", { "bin": { "pidtree": "bin/pidtree.js" } }, "sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g=="],
+
+    "pirates": ["pirates@4.0.7", "", {}, "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA=="],
 
     "postcss": ["postcss@8.5.9", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw=="],
 
@@ -2143,6 +2196,8 @@
     "svg-parser": ["svg-parser@2.0.4", "", {}, "sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ=="],
 
     "svgo": ["svgo@4.0.1", "", { "dependencies": { "commander": "^11.1.0", "css-select": "^5.1.0", "css-tree": "^3.0.1", "css-what": "^6.1.0", "csso": "^5.0.5", "picocolors": "^1.1.1", "sax": "^1.5.0" }, "bin": "./bin/svgo.js" }, "sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w=="],
+
+    "swc-node": ["swc-node@1.0.0", "", { "dependencies": { "@swc-node/register": "^1.4.0" }, "bin": { "swc-node": "bin/swc-node" } }, "sha512-4+kibROq06E7Yj3kEcCRN1Ki2C/5i+5P1B7An9iS9PO1BQY5VzWFuLhV7y7xNxkZjc8FEaLCh97NGzs/XBfOMQ=="],
 
     "tar-stream": ["tar-stream@2.2.0", "", { "dependencies": { "bl": "^4.0.3", "end-of-stream": "^1.4.1", "fs-constants": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.1.1" } }, "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ=="],
 
@@ -2350,6 +2405,8 @@
 
     "@mdx-js/mdx/source-map": ["source-map@0.7.6", "", {}, "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="],
 
+    "@oxc-resolver/binding-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
+
     "@rolldown/binding-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.3", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ=="],
 
     "@shikijs/core/@shikijs/types": ["@shikijs/types@4.0.2", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg=="],
@@ -2357,6 +2414,8 @@
     "@shikijs/engine-javascript/@shikijs/types": ["@shikijs/types@4.0.2", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg=="],
 
     "@shikijs/primitive/@shikijs/types": ["@shikijs/types@4.0.2", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg=="],
+
+    "@swc-node/sourcemap-support/source-map-support": ["source-map-support@0.5.21", "", { "dependencies": { "buffer-from": "^1.0.0", "source-map": "^0.6.0" } }, "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w=="],
 
     "@vitejs/plugin-vue/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.2", "", {}, "sha512-izyXV/v+cHiRfozX62W9htOAvwMo4/bXKDrQ+vom1L1qRuexPock/7VZDAhnpHCLNejd3NJ6hiab+tO0D44Rgw=="],
 
@@ -2583,6 +2642,8 @@
     "@expressive-code/plugin-shiki/shiki/@shikijs/core": ["@shikijs/core@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA=="],
 
     "@expressive-code/plugin-shiki/shiki/@shikijs/engine-javascript": ["@shikijs/engine-javascript@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2", "oniguruma-to-es": "^4.3.4" } }, "sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA=="],
+
+    "@oxc-resolver/binding-wasm32-wasi/@napi-rs/wasm-runtime/@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
     "@rolldown/binding-wasm32-wasi/@napi-rs/wasm-runtime/@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 

--- a/nx.json
+++ b/nx.json
@@ -58,7 +58,9 @@
 		},
 		"changelog": {
 			"workspaceChangelog": false,
-			"projectChangelogs": {}
+			"projectChangelogs": {
+				"renderer": "{workspaceRoot}/.nx/scripts/changelog-render.ts"
+			}
 		},
 		"git": {
 			"commit": true,

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
 		"@typescript/native-preview": "^7.0.0-dev.20260412.1",
 		"npm-run-all2": "^8.0.4",
 		"nx": "^22.6.0",
+		"swc-node": "^1.0.0",
 		"tsdown": "catalog:"
 	},
 	"scripts": {

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,18 +1,18 @@
 ## 0.4.0 (2026-04-14)
 
-### 🚀 Features
+### Minor Changes
 
-- chore: 移除 canvas 歌词渲染器 ([#476](https://github.com/amll-dev/applemusic-like-lyrics/pull/476))
+- **chore:** 移除 canvas 歌词渲染器 ([#476](https://github.com/amll-dev/applemusic-like-lyrics/pull/476))
 
-### 🩹 Fixes
+### Patch Changes
 
-- refactor: 重构核心库测试组织模式 ([3db83c93](https://github.com/amll-dev/applemusic-like-lyrics/commit/3db83c93))
-- chore: 更换工具链 ([#476](https://github.com/amll-dev/applemusic-like-lyrics/pull/476))
-- chore: 在项目范围内启用 isolatedDeclarations ([#480](https://github.com/amll-dev/applemusic-like-lyrics/pull/480))
-- docs: 修正 optimize-lyric.ts 和 OptimizeLyricOptions 里 cleanUnintentionalOverlaps 的文档和注释 ([75a8c0bb](https://github.com/amll-dev/applemusic-like-lyrics/commit/75a8c0bb))
+- **refactor:** 重构核心库测试组织模式 ([3db83c93](https://github.com/amll-dev/applemusic-like-lyrics/commit/3db83c93))
+- **docs:** 修正 optimize-lyric.ts 和 OptimizeLyricOptions 里 cleanUnintentionalOverlaps 的文档和注释 ([75a8c0bb](https://github.com/amll-dev/applemusic-like-lyrics/commit/75a8c0bb))
+- **chore:** 更换工具链 ([#476](https://github.com/amll-dev/applemusic-like-lyrics/pull/476))
+- **chore:** 在项目范围内启用 isolatedDeclarations ([#480](https://github.com/amll-dev/applemusic-like-lyrics/pull/480))
 
-### ❤️ Thank You
+### Contributors
 
-- apoint123 @apoint123
-- Linho @Linho1219
-- MoYingJi @MoYingJi
+- apoint123 [@apoint123](https://github.com/apoint123)
+- Linho [@Linho1219](https://github.com/Linho1219)
+- MoYingJi [@MoYingJi](https://github.com/MoYingJi)

--- a/packages/lyric/CHANGELOG.md
+++ b/packages/lyric/CHANGELOG.md
@@ -1,25 +1,25 @@
 ## 1.0.0-alpha.0 (2026-04-14)
 
-### 🚀 Features
+### Major Changes
 
-- refactor: 重构 TTML 解析和生成器 ([#471](https://github.com/amll-dev/applemusic-like-lyrics/pull/471))
+- **refactor:** 使用 TS 重写歌词正反解逻辑 ([56fd547c](https://github.com/amll-dev/applemusic-like-lyrics/commit/56fd547c))
 
-### 🩹 Fixes
+### Minor Changes
 
-- fix: 修复接驳错误导致的 ttml 输出对象结构问题 ([3418d391](https://github.com/amll-dev/applemusic-like-lyrics/commit/3418d391))
-- fix: 修复 lyric 包函数导出名误修改 ([1a81fcd1](https://github.com/amll-dev/applemusic-like-lyrics/commit/1a81fcd1))
-- fix: 修复 lyric 包在 isolatedDeclarations 下的类型问题 ([d2060cd9](https://github.com/amll-dev/applemusic-like-lyrics/commit/d2060cd9))
-- chore: 更换工具链 ([#476](https://github.com/amll-dev/applemusic-like-lyrics/pull/476))
+- **refactor:** 重构 TTML 解析和生成器 ([#471](https://github.com/amll-dev/applemusic-like-lyrics/pull/471))
 
-### ⚠️  Breaking Changes
+### Patch Changes
 
-- refactor: 使用 TS 重写歌词正反解逻辑 ([56fd547c](https://github.com/amll-dev/applemusic-like-lyrics/commit/56fd547c))
+- **fix:** 修复接驳错误导致的 ttml 输出对象结构问题 ([3418d391](https://github.com/amll-dev/applemusic-like-lyrics/commit/3418d391))
+- **fix:** 修复 lyric 包函数导出名误修改 ([1a81fcd1](https://github.com/amll-dev/applemusic-like-lyrics/commit/1a81fcd1))
+- **fix:** 修复 lyric 包在 isolatedDeclarations 下的类型问题 ([d2060cd9](https://github.com/amll-dev/applemusic-like-lyrics/commit/d2060cd9))
+- **chore:** 更换工具链 ([#476](https://github.com/amll-dev/applemusic-like-lyrics/pull/476))
 
-### 🧱 Updated Dependencies
+### Updated Dependencies
 
-- Updated @applemusic-like-lyrics/ttml to 1.0.0-alpha.0
+- Updated `@applemusic-like-lyrics/ttml` to `1.0.0-alpha.0`
 
-### ❤️ Thank You
+### Contributors
 
-- apoint123 @apoint123
-- Linho @Linho1219
+- apoint123 [@apoint123](https://github.com/apoint123)
+- Linho [@Linho1219](https://github.com/Linho1219)

--- a/packages/react-full/CHANGELOG.md
+++ b/packages/react-full/CHANGELOG.md
@@ -1,26 +1,26 @@
 ## 0.3.1 (2026-04-14)
 
-### 🩹 Fixes
+### Patch Changes
 
-- ci: 修复工作流错误导致的不成功发布 ([#483](https://github.com/amll-dev/applemusic-like-lyrics/pull/483))
+- **ci:** 修复工作流错误导致的不成功发布 ([#483](https://github.com/amll-dev/applemusic-like-lyrics/pull/483))
 
-### ❤️ Thank You
+### Contributors
 
-- Linho
+- Linho [@Linho1219](https://github.com/Linho1219)
 
 ## 0.3.0 (2026-04-14)
 
-### 🚀 Features
+### Minor Changes
 
-- chore: 移除 canvas 歌词渲染器 ([#476](https://github.com/amll-dev/applemusic-like-lyrics/pull/476))
+- **chore:** 移除 canvas 歌词渲染器 ([#476](https://github.com/amll-dev/applemusic-like-lyrics/pull/476))
 
-### 🩹 Fixes
+### Patch Changes
 
-- chore: 更换工具链 ([#476](https://github.com/amll-dev/applemusic-like-lyrics/pull/476))
-- fix: 修复纵向布局下封面定位错误 ([0f5805f7](https://github.com/amll-dev/applemusic-like-lyrics/commit/0f5805f7))
-- chore: 在项目范围内启用 isolatedDeclarations ([#480](https://github.com/amll-dev/applemusic-like-lyrics/pull/480))
+- **fix:** 修复纵向布局下封面定位错误 ([0f5805f7](https://github.com/amll-dev/applemusic-like-lyrics/commit/0f5805f7))
+- **chore:** 更换工具链 ([#476](https://github.com/amll-dev/applemusic-like-lyrics/pull/476))
+- **chore:** 在项目范围内启用 isolatedDeclarations ([#480](https://github.com/amll-dev/applemusic-like-lyrics/pull/480))
 
-### ❤️ Thank You
+### Contributors
 
-- apoint123 @apoint123
-- Linho
+- apoint123 [@apoint123](https://github.com/apoint123)
+- Linho [@Linho1219](https://github.com/Linho1219)

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,18 +1,18 @@
 ## 0.4.0 (2026-04-14)
 
-### 🚀 Features
+### Minor Changes
 
-- chore: 移除 canvas 歌词渲染器 ([#476](https://github.com/amll-dev/applemusic-like-lyrics/pull/476))
+- **chore:** 移除 canvas 歌词渲染器 ([#476](https://github.com/amll-dev/applemusic-like-lyrics/pull/476))
 
-### 🩹 Fixes
+### Patch Changes
 
-- refactor: 重构核心库测试组织模式 ([3db83c93](https://github.com/amll-dev/applemusic-like-lyrics/commit/3db83c93))
-- chore: 更换工具链 ([#476](https://github.com/amll-dev/applemusic-like-lyrics/pull/476))
-- chore: 在项目范围内启用 isolatedDeclarations ([#480](https://github.com/amll-dev/applemusic-like-lyrics/pull/480))
-- docs: 修正 optimize-lyric.ts 和 OptimizeLyricOptions 里 cleanUnintentionalOverlaps 的文档和注释 ([75a8c0bb](https://github.com/amll-dev/applemusic-like-lyrics/commit/75a8c0bb))
+- **refactor:** 重构核心库测试组织模式 ([3db83c93](https://github.com/amll-dev/applemusic-like-lyrics/commit/3db83c93))
+- **docs:** 修正 optimize-lyric.ts 和 OptimizeLyricOptions 里 cleanUnintentionalOverlaps 的文档和注释 ([75a8c0bb](https://github.com/amll-dev/applemusic-like-lyrics/commit/75a8c0bb))
+- **chore:** 更换工具链 ([#476](https://github.com/amll-dev/applemusic-like-lyrics/pull/476))
+- **chore:** 在项目范围内启用 isolatedDeclarations ([#480](https://github.com/amll-dev/applemusic-like-lyrics/pull/480))
 
-### ❤️ Thank You
+### Contributors
 
-- apoint123 @apoint123
-- Linho @Linho1219
-- MoYingJi @MoYingJi
+- apoint123 [@apoint123](https://github.com/apoint123)
+- Linho [@Linho1219](https://github.com/Linho1219)
+- MoYingJi [@MoYingJi](https://github.com/MoYingJi)

--- a/packages/ttml/CHANGELOG.md
+++ b/packages/ttml/CHANGELOG.md
@@ -1,14 +1,14 @@
 ## 1.0.0-alpha.0 (2026-04-14)
 
-### 🩹 Fixes
+### Major Changes
 
-- chore: 更换工具链 ([#476](https://github.com/amll-dev/applemusic-like-lyrics/pull/476))
+- **refactor:** 重构 TTML 解析和生成器 ([#471](https://github.com/amll-dev/applemusic-like-lyrics/pull/471))
 
-### ⚠️  Breaking Changes
+### Patch Changes
 
-- refactor: 重构 TTML 解析和生成器 ([#471](https://github.com/amll-dev/applemusic-like-lyrics/pull/471))
+- **chore:** 更换工具链 ([#476](https://github.com/amll-dev/applemusic-like-lyrics/pull/476))
 
-### ❤️ Thank You
+### Contributors
 
-- apoint123 @apoint123
-- Linho @Linho1219
+- apoint123 [@apoint123](https://github.com/apoint123)
+- Linho [@Linho1219](https://github.com/Linho1219)

--- a/packages/vue/CHANGELOG.md
+++ b/packages/vue/CHANGELOG.md
@@ -1,18 +1,18 @@
 ## 0.4.0 (2026-04-14)
 
-### 🚀 Features
+### Minor Changes
 
-- chore: 移除 canvas 歌词渲染器 ([#476](https://github.com/amll-dev/applemusic-like-lyrics/pull/476))
+- **chore:** 移除 canvas 歌词渲染器 ([#476](https://github.com/amll-dev/applemusic-like-lyrics/pull/476))
 
-### 🩹 Fixes
+### Patch Changes
 
-- refactor: 重构核心库测试组织模式 ([3db83c93](https://github.com/amll-dev/applemusic-like-lyrics/commit/3db83c93))
-- chore: 更换工具链 ([#476](https://github.com/amll-dev/applemusic-like-lyrics/pull/476))
-- chore: 在项目范围内启用 isolatedDeclarations ([#480](https://github.com/amll-dev/applemusic-like-lyrics/pull/480))
-- docs: 修正 optimize-lyric.ts 和 OptimizeLyricOptions 里 cleanUnintentionalOverlaps 的文档和注释 ([75a8c0bb](https://github.com/amll-dev/applemusic-like-lyrics/commit/75a8c0bb))
+- **refactor:** 重构核心库测试组织模式 ([3db83c93](https://github.com/amll-dev/applemusic-like-lyrics/commit/3db83c93))
+- **docs:** 修正 optimize-lyric.ts 和 OptimizeLyricOptions 里 cleanUnintentionalOverlaps 的文档和注释 ([75a8c0bb](https://github.com/amll-dev/applemusic-like-lyrics/commit/75a8c0bb))
+- **chore:** 更换工具链 ([#476](https://github.com/amll-dev/applemusic-like-lyrics/pull/476))
+- **chore:** 在项目范围内启用 isolatedDeclarations ([#480](https://github.com/amll-dev/applemusic-like-lyrics/pull/480))
 
-### ❤️ Thank You
+### Contributors
 
-- apoint123 @apoint123
-- Linho @Linho1219
-- MoYingJi @MoYingJi
+- apoint123 [@apoint123](https://github.com/apoint123)
+- Linho [@Linho1219](https://github.com/Linho1219)
+- MoYingJi [@MoYingJi](https://github.com/MoYingJi)


### PR DESCRIPTION
覆写 nx 生成 changlog 的逻辑，并修改了存量的 changelog。

同时在 actions 中补充了 setup Node，否则实际上用的是 `jetli/wasm-pack-action@v0.4.0` 中的 Node 22