### PR TITLE
fix(vue): 修复掩码模式错误的类型

### DIFF
--- a/.nx/version-plans/version-plan-1776953966782.md
+++ b/.nx/version-plans/version-plan-1776953966782.md
@@ -1,0 +1,5 @@
+---
+core-bundle: patch
+---
+
+fix(vue): 修复掩码模式错误的类型

--- a/packages/vue/src/LyricPlayer.tsx
+++ b/packages/vue/src/LyricPlayer.tsx
@@ -103,7 +103,7 @@ const lyricPlayerProps = {
 	 * 设置歌词中不雅用语的掩码模式，默认为 `MaskObsceneWordsMode.Disabled`，即不掩码
 	 */
 	maskObsceneWordsMode: {
-		type: Object as PropType<MaskObsceneWordsMode>,
+		type: String as PropType<MaskObsceneWordsMode>,
 		default: MaskObsceneWordsMode.Disabled,
 	},
 	/**


### PR DESCRIPTION
将 vue 绑定中歌词掩码模式的 prop 类型从 Object 改成正确的 String