### PR TITLE
fix: 修复背景行注音高度错误

### DIFF
--- a/.nx/version-plans/version-plan-1776956065994.md
+++ b/.nx/version-plans/version-plan-1776956065994.md
@@ -1,0 +1,5 @@
+---
+core-bundle: patch
+---
+
+fix: 修复背景行注音高度错误

--- a/packages/core/src/styles/index.css
+++ b/packages/core/src/styles/index.css
@@ -24,7 +24,7 @@
 		user-select: none;
 		box-sizing: content-box;
 		z-index: 1;
-		line-height: 1.2em;
+		line-height: 1.2;
 	}
 
 	&.dom-slim {
@@ -35,7 +35,7 @@
 		user-select: none;
 		box-sizing: content-box;
 		z-index: 1;
-		line-height: 1.2em;
+		line-height: 1.2;
 		min-height: 0;
 		min-width: 0;
 

--- a/packages/core/src/styles/lyric-player.module.css
+++ b/packages/core/src/styles/lyric-player.module.css
@@ -60,6 +60,10 @@
 	padding: 1vh
 		calc(var(--amll-lp-line-padding-x, 1em) / var(--amll-lp-bg-line-scale, 0.7));
 
+	.lyricMainLine {
+		padding: 1.2em 1em;
+	}
+
 	&.active {
 		transition:
 			opacity 0.5s 0.25s,


### PR DESCRIPTION
修复 #495。

原因在于此前行高设置为继承 `.dom` 的 `line-height: 2em`。此时背景行行高为 2 倍 `.dom` 字号，导致背景行的行高过大。改为 `line-height: 2` 则继承比值 2，背景行行高为 2 倍背景行字号。

为补偿背景行因此损失的边距，增加了上下 padding。