### PR TITLE
docs: GPT 5.5 主导的全方位更新文档

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -6,7 +6,7 @@
 
 [English](./README.md) / 简体中文
 
-一个基于 Web 技术制作的类 Apple Music 歌词显示组件库，同时支持[ DOM 原生](./packages/core/README.md)、[React ](./packages/react/README.md)和[ Vue ](./packages/react/README.md)绑定。
+一个基于 Web 技术制作的类 Apple Music 歌词显示组件库，同时支持 [DOM 原生](./packages/core/README-CN.md)、[React](./packages/react/README-CN.md) 和 [Vue](./packages/vue/README-CN.md) 绑定。
 
 这是你能在前端系里能见到的最像 iPad Apple Music 的播放页面了。
 
@@ -33,19 +33,21 @@
 -   [![AMLL-Core](https://img.shields.io/badge/Core-%233178c6?label=Apple%20Music-like%20Lyrics&labelColor=%23FB5C74)](./packages/core/README.md)：AMLL 核心组件库，以 DOM 原生方式编写，提供歌词显示组件和动态流体背景组件
 -   [![AMLL-React](https://img.shields.io/badge/React-%23149eca?label=Apple%20Music-like%20Lyrics&labelColor=%23FB5C74)](./packages/react/README.md)：AMLL React 绑定，提供 React 组件形式的歌词显示组件和动态流体背景组件
 -   [![AMLL-Vue](https://img.shields.io/badge/Vue-%2342d392?label=Apple%20Music-like%20Lyrics&labelColor=%23FB5C74)](./packages/vue/README.md)：AMLL Vue 绑定，提供 Vue 组件形式的歌词显示组件和动态流体背景组件
--   [![AMLL-Lyric](https://img.shields.io/badge/Lyric-%23FB8C84?label=Apple%20Music-like%20Lyrics&labelColor=%23FB5C74)](./packages/lyric/README.md)：AMLL 歌词解析模块，提供对 LyRiC, YRC, QRC, Lyricify Syllable 各种歌词格式的解析和序列化支持
+-   [![AMLL-React-Full](https://img.shields.io/badge/React%20Full-%23149eca?label=Apple%20Music-like%20Lyrics&labelColor=%23FB5C74)](./packages/react-full/README-CN.md)：AMLL React 完整播放器组件库，提供可组合的播放页面组件
+-   [![AMLL-TTML](https://img.shields.io/badge/TTML-%23FB8C84?label=Apple%20Music-like%20Lyrics&labelColor=%23FB5C74)](./packages/ttml/README-CN.md)：AMLL TTML 解析与生成模块，提供 TTML 到 Core `LyricLine[]` 的转换能力
+-   [![AMLL-Lyric](https://img.shields.io/badge/Lyric-%23FB8C84?label=Apple%20Music-like%20Lyrics&labelColor=%23FB5C74)](./packages/lyric/README-CN.md)：AMLL 多格式歌词解析模块，提供 LRC、YRC、QRC、Lyricify、TTML 等格式的解析和序列化支持
 
 ## 浏览器兼容性提醒
 
 本组件框架最低要求使用以下浏览器或更新版本：
 
--   Chromuim/Edge 91+
+-   Chromium/Edge 91+
 -   Firefox 100+
 -   Safari 9.1+
 
 完整呈现组件所有效果需要使用以下浏览器或更新版本：
 
--   Chromuim 120+
+-   Chromium 120+
 -   Firefox 100+
 -   Safari 15.4+
 

--- a/README.md
+++ b/README.md
@@ -28,10 +28,12 @@ Although the goal of this project is not to imitate it completely, it will polis
 
 ### Main modules
 
--   [![AMLL-Core](https://img.shields.io/badge/Core-%233178c6?label=Apple%20Music-like%20Lyrics&labelColor=%23FB5C74)](./packages/core/README.md): AMLL Core Component Library, written natively with DOM, provides lyric display component and dynamic fluid background component
--   [![AMLL-React](https://img.shields.io/badge/React-%23149eca?label=Apple%20Music-like%20Lyrics&labelColor=%23FB5C74)](./packages/react/README.md): AMLL React binding, provides React component forms of lyric display and dynamic fluid background components
--   [![AMLL-Vue](https://img.shields.io/badge/Vue-%2342d392?label=Apple%20Music-like%20Lyrics&labelColor=%23FB5C74)](./packages/vue/README.md): AMLL Vue binding, provides Vue component forms of lyric display and dynamic fluid background components
--   [![AMLL-Lyric](https://img.shields.io/badge/Lyric-%23FB8C84?label=Apple%20Music-like%20Lyrics&labelColor=%23FB5C74)](./packages/lyric/README.md): AMLL lyric parsing module, provides parsing and serialization support for various lyric formats including LyRiC, YRC, QRC, and Lyricify Syllable
+-   [![AMLL-Core](https://img.shields.io/badge/Core-%233178c6?label=Apple%20Music-like%20Lyrics&labelColor=%23FB5C74)](./packages/core/README.md): AMLL Core DOM component library, providing lyric display and animated background components
+-   [![AMLL-React](https://img.shields.io/badge/React-%23149eca?label=Apple%20Music-like%20Lyrics&labelColor=%23FB5C74)](./packages/react/README.md): React bindings for the Core lyric display and animated background components
+-   [![AMLL-Vue](https://img.shields.io/badge/Vue-%2342d392?label=Apple%20Music-like%20Lyrics&labelColor=%23FB5C74)](./packages/vue/README.md): Vue bindings for the Core lyric display and animated background components
+-   [![AMLL-React-Full](https://img.shields.io/badge/React%20Full-%23149eca?label=Apple%20Music-like%20Lyrics&labelColor=%23FB5C74)](./packages/react-full/README.md): Ready-to-use modular React player components
+-   [![AMLL-TTML](https://img.shields.io/badge/TTML-%23FB8C84?label=Apple%20Music-like%20Lyrics&labelColor=%23FB5C74)](./packages/ttml/README.md): TTML parser/generator with conversion to Core `LyricLine[]`
+-   [![AMLL-Lyric](https://img.shields.io/badge/Lyric-%23FB8C84?label=Apple%20Music-like%20Lyrics&labelColor=%23FB5C74)](./packages/lyric/README.md): Multi-format lyric parser/generator for LRC, YRC, QRC, Lyricify, TTML, and more
 
 ## Browser compatibility alerts
 

--- a/packages/core/README-CN.md
+++ b/packages/core/README-CN.md
@@ -8,74 +8,85 @@
 [![npm](https://img.shields.io/npm/dt/%40applemusic-like-lyrics/core)](https://www.npmjs.com/package/@applemusic-like-lyrics/core)
 [![npm](https://img.shields.io/npm/v/%40applemusic-like-lyrics%2Fcore)](https://www.npmjs.com/package/@applemusic-like-lyrics/core)
 
-AMLL 的纯 JS 核心组件框架，包括歌词显示组件和背景组件等其它可以复用的组件。
-
-此处的东西都是 UI 框架无关的，所以可以间接在各种动态页面框架下引用。
-
-或者如果你需要使用组件绑定的话，这里有 [React 绑定版本](../react/README.md) 和 [Vue 绑定版本](../vue/README.md)
-
-## 特性
-
-- 纯前端渲染的歌词展示与背景渲染
-- 动态逐字歌词、翻译与音译显示
-- 支持多行、对唱与背景行
-- 可通过 CSS 变量自定义颜色与部分表现
+AMLL Core 是框架无关的 DOM 组件库，提供歌词播放组件、背景渲染组件和相关类型。React/Vue 绑定都基于本包构建。
 
 ## 安装
 
-安装使用的依赖（如果以下列出的依赖包没有安装的话需要自行安装）：
 ```bash
-npm install @pixi/app @pixi/core @pixi/display @pixi/filter-blur @pixi/filter-bulge-pinch @pixi/filter-color-matrix @pixi/sprite # 使用 npm
-yarn add @pixi/app @pixi/core @pixi/display @pixi/filter-blur @pixi/filter-bulge-pinch @pixi/filter-color-matrix @pixi/sprite # 使用 yarn
+npm install @applemusic-like-lyrics/core @applemusic-like-lyrics/ttml
+npm install @pixi/app @pixi/core @pixi/display @pixi/filter-blur @pixi/filter-bulge-pinch @pixi/filter-color-matrix @pixi/sprite
 ```
 
-安装本体框架：
-```bash
-npm install @applemusic-like-lyrics/core # 使用 npm
-yarn add @applemusic-like-lyrics/core # 使用 yarn
-```
+如果使用 pnpm 或 Yarn，将 `npm install` 替换为 `pnpm add` 或 `yarn add`。部分包管理器会自动安装 peer 依赖；如果构建时提示缺少 `@pixi/*`，请显式安装上面的 Pixi 包。
 
-## 使用方式摘要
+## 基本使用
 
-详细的 API 文档请参考 [./docs/modules.md](./docs/modules.md)
-
-一个测试用途的程序可以在 [../playground/core/src/test.ts](../playground/core/src/test.ts) 里找到。
-
-```typescript
+```ts
 import { LyricPlayer } from "@applemusic-like-lyrics/core";
-import "@applemusic-like-lyrics/core/style.css"; // 导入需要的样式
+import { parseTTML } from "@applemusic-like-lyrics/ttml";
+import "@applemusic-like-lyrics/core/style.css";
 
-const player = new LyricPlayer(); // 创建歌词播放组件
-document.body.appendChild(player.getElement()); // 将组件的元素添加到页面
-player.setLyricLines([]) // 设置歌词
-player.setCurrentTime(0) // 设定当前播放时间（需要逐帧调用）
-player.update(0) // 更新歌词组件动画（需要逐帧调用）
+const audio = document.querySelector<HTMLAudioElement>("#audio")!;
+const player = new LyricPlayer();
+
+document.body.appendChild(player.getElement());
+
+const ttmlText = await fetch("/lyrics.ttml").then((res) => res.text());
+player.setLyricLines(parseTTML(ttmlText).lines);
+player.setCurrentTime(0, true);
+player.update(0);
+
+let lastFrameTime = -1;
+
+function frame(time: number) {
+    if (lastFrameTime === -1) lastFrameTime = time;
+    const delta = time - lastFrameTime;
+    lastFrameTime = time;
+
+    if (!audio.paused) {
+        player.setCurrentTime(Math.floor(audio.currentTime * 1000));
+    }
+
+    player.update(delta);
+    requestAnimationFrame(frame);
+}
+
+requestAnimationFrame(frame);
 ```
 
-每次通过 `LyricPlayer.setLyricLines` 设置的歌词是一个 `LyricLine[]` 参数，具体可以参考 [./src/interfaces.ts](./src/interfaces.ts) 中的代码。
+要点：
+
+- `setLyricLines()` 接收 Core 的 `LyricLine[]`，TTML 推荐使用 `@applemusic-like-lyrics/ttml` 的 `parseTTML(ttmlText).lines`。
+- `setCurrentTime()` 的单位是整数毫秒；拖动进度条或点击歌词跳转时，将第二个参数设为 `true`。
+- `update(deltaMs)` 推进动画，应在组件挂载后逐帧调用。
+- 组件不用时调用 `dispose()` 释放资源。
 
 ## 数据结构
 
-歌词的输入结构为 `LyricLine[]`，其中每行包含：
+`LyricLine[]` 中每行包含：
 
-- `words`: 逐字歌词数组，每个单词包含 `startTime` / `endTime` / `word`，并可选包含 `romanWord`、`ruby`、`obscene` 等字段
-- `translatedLyric`: 翻译行文本
-- `romanLyric`: 音译行文本
-- `startTime` / `endTime`: 行级时间戳
-- `isBG` / `isDuet`: 背景行与对唱行标记
+- `words`: 逐词歌词数组，每个单词包含 `startTime`、`endTime`、`word`，并可选包含 `romanWord`、`ruby`、`obscene`
+- `translatedLyric`: 翻译文本
+- `romanLyric`: 音译文本
+- `startTime` / `endTime`: 行级时间戳，单位毫秒
+- `isBG` / `isDuet`: 背景人声与对唱标记
 
-## 样式定制
+## 样式
 
-主要样式由 `@applemusic-like-lyrics/core/style.css` 提供，常用自定义方式为覆写 CSS 变量，例如：
+必须引入 `@applemusic-like-lyrics/core/style.css`。常用自定义方式是覆写 CSS 变量：
 
 ```css
 .amll-lyric-player {
-  --amll-lp-color: #ffffff;
-  --amll-lp-bg-color: rgba(0, 0, 0, 0.35);
+    --amll-lp-color: #ffffff;
+    --amll-lp-bg-color: rgba(0, 0, 0, 0.35);
 }
 ```
 
-## 开发与构建
+## 文档与开发
+
+- 使用指南：https://amll.dev/guides/overview/quickstart
+- API 参考：https://amll.dev/reference/core
+- 调试示例：`packages/playground/core`
 
 ```bash
 bun run --cwd packages/core dev

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -2,80 +2,91 @@
 
 English / [简体中文](./README-CN.md)
 
-> Warning: This is a personal project and is still under development. There may still be many issues, so please do not use it directly in production environments!
+> Warning: This is a personal project and is still under development. There may still be many issues, so please do not use it directly in production environments.
 
 ![AMLL-Core](https://img.shields.io/badge/Core-%233178c6?label=Apple%20Music-like%20Lyrics&labelColor=%23FB5C74)
 [![npm](https://img.shields.io/npm/dt/%40applemusic-like-lyrics/core)](https://www.npmjs.com/package/@applemusic-like-lyrics/core)
 [![npm](https://img.shields.io/npm/v/%40applemusic-like-lyrics%2Fcore)](https://www.npmjs.com/package/@applemusic-like-lyrics/core)
 
-AMLL's pure JS core component framework, including lyric display components and background components and other reusable components.
-
-Everything here is UI framework-independent, so it can be indirectly referenced under various dynamic page frameworks.
-
-Or if you need to use component bindings, there's a [React binding version](../react/README.md) and a [Vue binding version](../vue/README.md)
-
-## Features
-
-- Pure frontend rendering for lyrics and background
-- Word-level timed lyrics with translation and romanization
-- Multi-line, duet, and background line support
-- Style customization via CSS variables
+AMLL Core is the framework-agnostic DOM component package. It provides the lyric player, background renderer, and shared types. The React and Vue bindings are built on top of this package.
 
 ## Installation
 
-Install the required dependencies (if the dependencies listed below are not installed, you need to install them yourself):
 ```bash
-npm install @pixi/app @pixi/core @pixi/display @pixi/filter-blur @pixi/filter-bulge-pinch @pixi/filter-color-matrix @pixi/sprite # using npm
-yarn add @pixi/app @pixi/core @pixi/display @pixi/filter-blur @pixi/filter-bulge-pinch @pixi/filter-color-matrix @pixi/sprite # using yarn
+npm install @applemusic-like-lyrics/core @applemusic-like-lyrics/ttml
+npm install @pixi/app @pixi/core @pixi/display @pixi/filter-blur @pixi/filter-bulge-pinch @pixi/filter-color-matrix @pixi/sprite
 ```
 
-Install the framework:
-```bash
-npm install @applemusic-like-lyrics/core # using npm
-yarn add @applemusic-like-lyrics/core # using yarn
-```
+For pnpm or Yarn, replace `npm install` with `pnpm add` or `yarn add`. Some package managers install peer dependencies automatically; if your build reports missing `@pixi/*` packages, install the Pixi packages above explicitly.
 
-## Usage Summary
+## Basic Usage
 
-For detailed API documentation, please refer to [./docs/modules.md](./docs/modules.md)
-
-A test program can be found in [../playground/core/src/test.ts](../playground/core/src/test.ts).
-
-```typescript
+```ts
 import { LyricPlayer } from "@applemusic-like-lyrics/core";
-import "@applemusic-like-lyrics/core/style.css"; // Import required styles
+import { parseTTML } from "@applemusic-like-lyrics/ttml";
+import "@applemusic-like-lyrics/core/style.css";
 
-const player = new LyricPlayer(); // Create a lyric player component
-document.body.appendChild(player.getElement()); // Add the component's element to the page
-player.setLyricLines([]) // Set lyrics
-player.setCurrentTime(0) // Set current playback time (needs to be called every frame)
-player.update(0) // Update lyric component animation (needs to be called every frame)
+const audio = document.querySelector<HTMLAudioElement>("#audio")!;
+const player = new LyricPlayer();
+
+document.body.appendChild(player.getElement());
+
+const ttmlText = await fetch("/lyrics.ttml").then((res) => res.text());
+player.setLyricLines(parseTTML(ttmlText).lines);
+player.setCurrentTime(0, true);
+player.update(0);
+
+let lastFrameTime = -1;
+
+function frame(time: number) {
+    if (lastFrameTime === -1) lastFrameTime = time;
+    const delta = time - lastFrameTime;
+    lastFrameTime = time;
+
+    if (!audio.paused) {
+        player.setCurrentTime(Math.floor(audio.currentTime * 1000));
+    }
+
+    player.update(delta);
+    requestAnimationFrame(frame);
+}
+
+requestAnimationFrame(frame);
 ```
 
-The lyrics set through `LyricPlayer.setLyricLines` is a `LyricLine[]` parameter. For details, please refer to the code in [./src/interfaces.ts](./src/interfaces.ts).
+Key points:
+
+- `setLyricLines()` accepts Core `LyricLine[]`. For TTML, use `parseTTML(ttmlText).lines` from `@applemusic-like-lyrics/ttml`.
+- `setCurrentTime()` uses integer milliseconds. Pass `true` as the second argument when the user seeks or jumps by clicking a lyric line.
+- `update(deltaMs)` advances animation and should be called every frame while the component is mounted.
+- Call `dispose()` when the component is no longer used.
 
 ## Data Model
 
-Lyrics input is `LyricLine[]`, with each line containing:
+`LyricLine[]` contains:
 
-- `words`: timed word array, each word includes `startTime` / `endTime` / `word`, with optional `romanWord`, `ruby`, and `obscene`
-- `translatedLyric`: translation text
-- `romanLyric`: romanization text
-- `startTime` / `endTime`: line timestamps
-- `isBG` / `isDuet`: background and duet flags
+- `words`: timed words, each with `startTime`, `endTime`, `word`, and optional `romanWord`, `ruby`, `obscene`
+- `translatedLyric`: translated text
+- `romanLyric`: romanized text
+- `startTime` / `endTime`: line timestamps in milliseconds
+- `isBG` / `isDuet`: background-vocal and duet flags
 
 ## Styling
 
-The main styles are provided by `@applemusic-like-lyrics/core/style.css`. Common overrides are via CSS variables:
+Import `@applemusic-like-lyrics/core/style.css`. Common customization is done by overriding CSS variables:
 
 ```css
 .amll-lyric-player {
-  --amll-lp-color: #ffffff;
-  --amll-lp-bg-color: rgba(0, 0, 0, 0.35);
+    --amll-lp-color: #ffffff;
+    --amll-lp-bg-color: rgba(0, 0, 0, 0.35);
 }
 ```
 
-## Development
+## Docs and Development
+
+- Guide: https://amll.dev/en/guides/overview/quickstart
+- API reference: https://amll.dev/en/reference/core
+- Playground: `packages/playground/core`
 
 ```bash
 bun run --cwd packages/core dev

--- a/packages/docs/src/content/docs/en/guides/overview/quickstart.mdx
+++ b/packages/docs/src/content/docs/en/guides/overview/quickstart.mdx
@@ -9,126 +9,38 @@ import {
     TabItem,
 } from "@astrojs/starlight/components";
 
-This page quickly shows how to integrate AMLL lyric components into your project. AMLL does not provide CDN script usage; a bundler is required.
+AMLL does not ship a CDN build. Use it in a bundler environment such as Vite, Webpack, Rspack, or a Next.js client component. This page covers the minimum rendering-component setup; for lyric parsing and TTML generation, see [Lyric Format Quick Start](/en/guides/lyric/quickstart) and the [API Reference](/en/reference).
 
-For tooling packages outside the rendering component libraries, see [API Reference](/en/reference).
-
-## Dependencies
-
-Install AMLL core library:
-
-<Tabs syncKey="pkg">
-<TabItem label="npm">
-
-```sh
-npm install @applemusic-like-lyrics/core
-```
-
-</TabItem>
-
-<TabItem label="pnpm">
-
-```sh
-pnpm add @applemusic-like-lyrics/core
-```
-
-</TabItem>
-
-<TabItem label="Yarn">
-
-```sh
-yarn add @applemusic-like-lyrics/core
-```
-
-</TabItem>
-</Tabs>
-
-AMLL also declares several graphics and animation libraries as peer dependencies to reuse dependencies that may already exist in your project. Some package managers/configurations install peers automatically; if not, install them manually.
-
-<Tabs syncKey="pkg">
-<TabItem label="npm">
-
-```sh
-npm install @pixi/app @pixi/core @pixi/display @pixi/filter-blur @pixi/filter-bulge-pinch @pixi/filter-color-matrix @pixi/sprite jss jss-preset-default
-```
-
-</TabItem>
-
-<TabItem label="pnpm">
-
-```sh
-pnpm add @pixi/app @pixi/core @pixi/display @pixi/filter-blur @pixi/filter-bulge-pinch @pixi/filter-color-matrix @pixi/sprite jss jss-preset-default
-```
-
-</TabItem>
-
-<TabItem label="Yarn">
-
-```sh
-yarn add @pixi/app @pixi/core @pixi/display @pixi/filter-blur @pixi/filter-bulge-pinch @pixi/filter-color-matrix @pixi/sprite jss jss-preset-default
-```
-
-</TabItem>
-</Tabs>
-
-Then you can use the vanilla package directly, or use React/Vue bindings.
+## Choose an Entry
 
 <CardGrid>
     <LinkCard
-        title="Use Vanilla"
-        description="Without a frontend framework"
-        href="#use-vanilla"
+        title="Core DOM"
+        description="Use the player instance directly without React or Vue"
+        href="#core-dom"
     />
     <LinkCard
-        title="Use React Bindings"
-        description="For React projects"
-        href="#use-react-bindings"
+        title="React Bindings"
+        description="Drive the player through React props"
+        href="#react-bindings"
     />
     <LinkCard
-        title="Use Vue Bindings"
-        description="For Vue projects"
-        href="#use-vue-bindings"
+        title="Vue Bindings"
+        description="Drive the player through Vue reactive props"
+        href="#vue-bindings"
     />
 </CardGrid>
 
-## Use Vanilla
+## Install Dependencies
 
-The AMLL core library is framework-agnostic. You can use this approach in any project.
-
-```js
-import { LyricPlayer } from "@applemusic-like-lyrics/core";
-
-// Create lyric player instance
-const player = new LyricPlayer();
-
-// Append the player's element to the page
-document.body.appendChild(player.getElement());
-
-// Set lyrics
-player.setLyricLines([]);
-
-// Set current playback time
-player.setCurrentTime(0);
-
-// Update animation frame
-player.update(0);
-```
-
-[`setLyricLines`](/en/reference/core/classlyricplayerbase#setlyriclines) accepts objects of type [`LyricLine`](/en/reference/core/interfacelyricline). Do not mutate the object after passing it in, or unexpected issues may occur.
-
-[`setCurrentTime`](/en/reference/core/classlyricplayerbase#setcurrenttime) and [`update`](/en/reference/core/classlyricplayerbase#update) accept current playback time (integer milliseconds), and **must be called frame by frame while playing**. Also call `update` once after each `setLyricLines` call to refresh state.
-
-See [API Reference: Core](/en/reference/core) for full details.
-
-## Use React Bindings
-
-Make sure `react` and `react-dom` are installed. Then install AMLL React bindings:
+The core renderer declares several Pixi packages as peer dependencies. npm 7+, pnpm, and Yarn Berry often install peers automatically. If your package manager does not, or your build reports missing `@pixi/*` packages, install them explicitly.
 
 <Tabs syncKey="pkg">
 <TabItem label="npm">
 
 ```sh
-npm install @applemusic-like-lyrics/react
+npm install @applemusic-like-lyrics/core @applemusic-like-lyrics/ttml
+npm install @pixi/app @pixi/core @pixi/display @pixi/filter-blur @pixi/filter-bulge-pinch @pixi/filter-color-matrix @pixi/sprite
 ```
 
 </TabItem>
@@ -136,7 +48,8 @@ npm install @applemusic-like-lyrics/react
 <TabItem label="pnpm">
 
 ```sh
-pnpm add @applemusic-like-lyrics/react
+pnpm add @applemusic-like-lyrics/core @applemusic-like-lyrics/ttml
+pnpm add @pixi/app @pixi/core @pixi/display @pixi/filter-blur @pixi/filter-bulge-pinch @pixi/filter-color-matrix @pixi/sprite
 ```
 
 </TabItem>
@@ -144,62 +57,182 @@ pnpm add @applemusic-like-lyrics/react
 <TabItem label="Yarn">
 
 ```sh
-yarn add @applemusic-like-lyrics/react
+yarn add @applemusic-like-lyrics/core @applemusic-like-lyrics/ttml
+yarn add @pixi/app @pixi/core @pixi/display @pixi/filter-blur @pixi/filter-bulge-pinch @pixi/filter-color-matrix @pixi/sprite
 ```
 
 </TabItem>
 </Tabs>
 
-The React binding package exports [`LyricPlayer`](/en/reference/react/variablelyricplayer) as the main component.
+`@applemusic-like-lyrics/ttml` converts TTML text into `LyricLine[]` that the AMLL player can consume directly: `parseTTML(ttmlText).lines`.
 
-```jsx
-import React, { useState } from "react";
-import { LyricPlayer } from "@applemusic-like-lyrics/react";
-import { parseTTML } from "@applemusic-like-lyrics/core";
+Every `LyricPlayer` entry needs the core stylesheet:
 
-const [currentTime, setCurrentTime] = useState(0);
-const [lyricLines, setLyricLines] = useState(0);
-const audio = document.getElementById("amll-audio"); // get <audio> element
+```ts
+import "@applemusic-like-lyrics/core/style.css";
+```
 
-const parsedResult = parseTTML(`SomeTtmlText...`); // parse lyrics
-setLyricLines(parsedResult);
+## Core DOM
 
-let lastTime = -1;
-const frame = (time) => {
-    if (lastTime === -1) {
-        lastTime = time;
-    }
+Use the Core package when you do not use a frontend framework, or when you want to manage the instance lifecycle yourself.
+
+```ts
+import { LyricPlayer } from "@applemusic-like-lyrics/core";
+import { parseTTML } from "@applemusic-like-lyrics/ttml";
+import "@applemusic-like-lyrics/core/style.css";
+
+const audio = document.querySelector<HTMLAudioElement>("#audio")!;
+const container = document.querySelector<HTMLElement>("#lyrics")!;
+const player = new LyricPlayer();
+
+container.appendChild(player.getElement());
+
+const ttmlText = await fetch("/lyrics.ttml").then((res) => res.text());
+player.setLyricLines(parseTTML(ttmlText).lines);
+player.setCurrentTime(0, true);
+player.update(0);
+
+let frameId = 0;
+let lastFrameTime = -1;
+
+function frame(time: number) {
+    if (lastFrameTime === -1) lastFrameTime = time;
+
+    const delta = time - lastFrameTime;
+    lastFrameTime = time;
+
     if (!audio.paused) {
-        const time = (audio.currentTime * 1000) | 0;
-        setCurrentTime(time);
+        player.setCurrentTime(Math.floor(audio.currentTime * 1000));
     }
-    lastTime = time;
-    requestAnimationFrame(frame);
-};
-requestAnimationFrame(frame);
+    player.update(delta);
 
-function App() {
+    frameId = requestAnimationFrame(frame);
+}
+
+frameId = requestAnimationFrame(frame);
+
+window.addEventListener("beforeunload", () => {
+    cancelAnimationFrame(frameId);
+    player.dispose();
+});
+```
+
+Key points:
+
+- `setLyricLines(lines, initialTime?)` accepts AMLL Core [`LyricLine[]`](/en/reference/core/interfacelyricline). Do not mutate the array objects after passing them in.
+- `setCurrentTime(ms, isSeek?)` uses integer milliseconds. Pass `true` for `isSeek` when the user seeks or jumps by clicking a lyric line.
+- `update(deltaMs)` advances animation. Call it every frame while the player is mounted; `deltaMs` is the elapsed time since the previous frame.
+- Call `dispose()` when the component is no longer used.
+
+## React Bindings
+
+Install the React binding package and React runtime:
+
+<Tabs syncKey="pkg">
+<TabItem label="npm">
+
+```sh
+npm install @applemusic-like-lyrics/react @applemusic-like-lyrics/ttml react react-dom
+```
+
+</TabItem>
+
+<TabItem label="pnpm">
+
+```sh
+pnpm add @applemusic-like-lyrics/react @applemusic-like-lyrics/ttml react react-dom
+```
+
+</TabItem>
+
+<TabItem label="Yarn">
+
+```sh
+yarn add @applemusic-like-lyrics/react @applemusic-like-lyrics/ttml react react-dom
+```
+
+</TabItem>
+</Tabs>
+
+`@applemusic-like-lyrics/react` depends on `@applemusic-like-lyrics/core`, so the Core Pixi peer dependencies and stylesheet are still required.
+
+```tsx
+import { useEffect, useRef, useState } from "react";
+import type { LyricLine } from "@applemusic-like-lyrics/core";
+import { LyricPlayer } from "@applemusic-like-lyrics/react";
+import { parseTTML } from "@applemusic-like-lyrics/ttml";
+import "@applemusic-like-lyrics/core/style.css";
+
+export function App() {
+    const audioRef = useRef<HTMLAudioElement>(null);
+    const [lyricLines, setLyricLines] = useState<LyricLine[]>([]);
+    const [currentTime, setCurrentTime] = useState(0);
+    const [playing, setPlaying] = useState(false);
+
+    useEffect(() => {
+        let canceled = false;
+        fetch("/lyrics.ttml")
+            .then((res) => res.text())
+            .then((text) => {
+                if (!canceled) setLyricLines(parseTTML(text).lines);
+            });
+
+        return () => {
+            canceled = true;
+        };
+    }, []);
+
+    useEffect(() => {
+        if (!playing) return;
+
+        let frameId = 0;
+        const frame = () => {
+            const audio = audioRef.current;
+            if (audio && !audio.paused) {
+                setCurrentTime(Math.floor(audio.currentTime * 1000));
+                frameId = requestAnimationFrame(frame);
+            }
+        };
+
+        frameId = requestAnimationFrame(frame);
+        return () => cancelAnimationFrame(frameId);
+    }, [playing]);
+
     return (
         <>
-            <audio id="amll-audio" src="Audio-Music-Src" controls />
-            <LyricPlayer lyricLines={lyricLines} currentTime={currentTime} />
+            <audio
+                ref={audioRef}
+                src="/song.mp3"
+                controls
+                onPlay={() => setPlaying(true)}
+                onPause={() => setPlaying(false)}
+                onSeeked={() => {
+                    const audio = audioRef.current;
+                    if (audio) setCurrentTime(Math.floor(audio.currentTime * 1000));
+                }}
+            />
+            <LyricPlayer
+                lyricLines={lyricLines}
+                currentTime={currentTime}
+                playing={playing}
+                style={{ height: 480 }}
+            />
         </>
     );
 }
-export default App;
 ```
 
-See [API Reference: React](/en/reference/react) for full interface documentation.
+The React binding calls Core `update()` internally every frame. Application code only needs to keep `currentTime` synced with audio playback and keep `playing` aligned with the audio state.
 
-## Use Vue Bindings
+## Vue Bindings
 
-Make sure Vue is installed. Then install AMLL Vue bindings:
+Install the Vue binding package and Vue:
 
 <Tabs syncKey="pkg">
 <TabItem label="npm">
 
 ```sh
-npm install @applemusic-like-lyrics/vue
+npm install @applemusic-like-lyrics/vue @applemusic-like-lyrics/ttml vue
 ```
 
 </TabItem>
@@ -207,7 +240,7 @@ npm install @applemusic-like-lyrics/vue
 <TabItem label="pnpm">
 
 ```sh
-pnpm add @applemusic-like-lyrics/vue
+pnpm add @applemusic-like-lyrics/vue @applemusic-like-lyrics/ttml vue
 ```
 
 </TabItem>
@@ -215,122 +248,66 @@ pnpm add @applemusic-like-lyrics/vue
 <TabItem label="Yarn">
 
 ```sh
-yarn add @applemusic-like-lyrics/vue
+yarn add @applemusic-like-lyrics/vue @applemusic-like-lyrics/ttml vue
 ```
 
 </TabItem>
 </Tabs>
 
-The Vue package exports [`LyricPlayer`](/en/reference/vue/classlyricplayer) as the main component.
-
-<Tabs syncKey="vapi">
-<TabItem label="Composition API">
+`@applemusic-like-lyrics/vue` depends on `@applemusic-like-lyrics/core`, so the Core Pixi peer dependencies and stylesheet are still required.
 
 ```vue
 <template>
-    <LyricPlayer
-        :lyric-lines="amllLyricLines"
-        :current-time="progressRef"
-        :playing="playingRef"
+    <audio
+        ref="audioRef"
+        src="/song.mp3"
+        controls
+        @play="onPlay"
+        @pause="playing = false"
+        @seeked="syncCurrentTime"
     />
-    <audio src="..." ref="audioElRef"></audio>
+    <LyricPlayer
+        :lyric-lines="lyricLines"
+        :current-time="currentTime"
+        :playing="playing"
+        style="height: 480px"
+    />
 </template>
 
 <script setup lang="ts">
-import { onMounted, ref, useTemplateRef } from "vue";
 import type { LyricLine } from "@applemusic-like-lyrics/core";
 import { LyricPlayer } from "@applemusic-like-lyrics/vue";
-
+import { parseTTML } from "@applemusic-like-lyrics/ttml";
+import { onMounted, ref, shallowRef } from "vue";
 import "@applemusic-like-lyrics/core/style.css";
 
-const amllLyricLines: LyricLine[] = [];
+const audioRef = ref<HTMLAudioElement>();
+const lyricLines = shallowRef<LyricLine[]>([]);
+const currentTime = ref(0);
+const playing = ref(false);
 
-const progressRef = ref(0);
-const playingRef = ref(false);
+onMounted(async () => {
+    const ttmlText = await fetch("/lyrics.ttml").then((res) => res.text());
+    lyricLines.value = parseTTML(ttmlText).lines;
+});
 
-const audioElRef = useTemplateRef("audioElRef");
-
-function onFrame() {
-    if (audioElRef.value)
-        progressRef.value = Math.round(audioElRef.value.currentTime * 1000);
-    if (playingRef.value) requestAnimationFrame(onFrame);
+function syncCurrentTime() {
+    const audio = audioRef.value;
+    if (audio) currentTime.value = Math.floor(audio.currentTime * 1000);
 }
 
-onMounted(() => {
-    if (!audioElRef.value) return;
-    audioElRef.value.addEventListener("play", () => {
-        playingRef.value = true;
-        requestAnimationFrame(onFrame);
-    });
-    audioElRef.value.addEventListener("pause", () => {
-        playingRef.value = false;
-    });
-});
+function onPlay() {
+    playing.value = true;
+
+    const frame = () => {
+        if (!playing.value) return;
+        syncCurrentTime();
+        requestAnimationFrame(frame);
+    };
+
+    requestAnimationFrame(frame);
+}
 </script>
 ```
 
-</TabItem>
-
-<TabItem label="Options API">
-
-```vue
-<template>
-    <LyricPlayer
-        :lyric-lines="amllLyricLines"
-        :current-time="progressRef"
-        :playing="playingRef"
-    />
-    <audio src="..." ref="audioElRef"></audio>
-</template>
-
-<script lang="ts">
-import { defineComponent } from "vue";
-import type { LyricLine } from "@applemusic-like-lyrics/core";
-import { LyricPlayer } from "@applemusic-like-lyrics/vue";
-
-import "@applemusic-like-lyrics/core/style.css";
-
-export default defineComponent({
-    components: {
-        LyricPlayer,
-    },
-    data() {
-        return {
-            amllLyricLines: [] as LyricLine[],
-            progressRef: 0,
-            playingRef: false,
-        };
-    },
-    mounted() {
-        const audioEl = this.$refs.audioElRef as HTMLAudioElement | null;
-        if (!audioEl) return;
-
-        audioEl.addEventListener("play", () => {
-            this.playingRef = true;
-            this.onFrame();
-        });
-
-        audioEl.addEventListener("pause", () => {
-            this.playingRef = false;
-        });
-    },
-    methods: {
-        onFrame() {
-            const audioEl = this.$refs.audioElRef as HTMLAudioElement | null;
-            if (audioEl) {
-                this.progressRef = Math.round(audioEl.currentTime * 1000);
-            }
-
-            if (this.playingRef) {
-                requestAnimationFrame(this.onFrame);
-            }
-        },
-    },
-});
-</script>
-```
-
-</TabItem>
-</Tabs>
-
-See [API Reference: Vue](/en/reference/vue) for full interface documentation.
+The Vue binding also advances animation internally. Application code only needs to pass lyric data, integer millisecond progress, and playback state through reactive props.

--- a/packages/docs/src/content/docs/en/guides/react/bg-render.mdx
+++ b/packages/docs/src/content/docs/en/guides/react/bg-render.mdx
@@ -2,30 +2,77 @@
 title: BackgroundRender Component
 ---
 
-## Overview
+`BackgroundRender` is AMLL's static/animated background component. The React binding uses Core `MeshGradientRenderer` by default, and receives cover artwork or video resources through the `album` prop.
 
-`BackgroundRender` is one of AMLL core components. AMLL's static and animated background rendering is handled by this component.
+## Basic Usage
 
-AMLL provides React bindings for `BackgroundRender`, so you can use it directly in React projects.
+```tsx
+import { BackgroundRender } from "@applemusic-like-lyrics/react";
 
-For a quick setup, see [AMLL React Quick Start](./quick-start).
+export function Background({ albumUrl, playing }: {
+    albumUrl: string;
+    playing: boolean;
+}) {
+    return (
+        <BackgroundRender
+            album={albumUrl}
+            playing={playing}
+            style={{ position: "absolute", inset: 0 }}
+        />
+    );
+}
+```
 
-## Usage
+If the album source is a video URL, set `albumIsVideo`:
 
-Please refer to [AMLL React Quick Start](./quick-start).
+```tsx
+<BackgroundRender album="/cover-video.mp4" albumIsVideo />
+```
 
 ## Props
 
-`BackgroundRender` is configurable through React props.
-
 | Prop | Type | Default | Description |
 | --- | --- | --- | --- |
-| `albumImageUrl` | `string` | `true` | Album artwork URL used for background rendering |
-| `fps` | `number` | `30` | Background animation frame rate |
-| `playing` | `boolean` | `true` | Current playback state |
-| `flowSpeed` | `number` | `2` | Animation flow speed |
-| `hasLyric` | `boolean` | `true` | Whether lyric availability should affect rendering behavior. If unknown, use `true` or keep default. |
-| `lowFreqVolume` | `number` | `1.0` | Low-frequency volume hint (recommended 80hz-120hz range, value `0.0-1.0`). Some renderers react to this (for example beat-like motion). If unavailable, pass `undefined`, `1.0`, or keep default. |
-| `renderScale` | `number` | `0.5` | Rendering scale ratio |
-| `staticMode` | `boolean` | `false` | Enable static mode (freeze image after switching, disable updates to save performance) |
-| `renderer` | `Canvas` | `EplorRenderer` | Background renderer implementation. Default renderer may change across versions. Newer default: `EplorRenderer`; legacy: `PixiRenderer`. |
+| `album` | `string \| HTMLImageElement \| HTMLVideoElement` | `undefined` | Album resource for the background: image URL, video URL, image element, or video element |
+| `albumIsVideo` | `boolean` | `false` | Set to `true` when `album` is a string pointing to a video resource |
+| `fps` | `number` | renderer default | Background animation frame rate; use `0` to stop animation |
+| `playing` | `boolean` | `true` | Playback state, used to pause or resume background animation |
+| `flowSpeed` | `number` | renderer default | Background flow speed |
+| `hasLyric` | `boolean` | `true` | Whether lyric availability should affect background behavior; keep the default if unsure |
+| `lowFreqVolume` | `number` | renderer default | Low-frequency volume hint, usually `0.0` to `1.0` |
+| `renderScale` | `number` | renderer default | Background render scale; lower values reduce GPU cost |
+| `staticMode` | `boolean` | `false` | Freeze the background after switching resources to save performance |
+| `renderer` | `new (canvas: HTMLCanvasElement) => BaseRenderer` | `MeshGradientRenderer` | Replace the underlying background renderer; pass `PixiRenderer` for the legacy background |
+
+The component also accepts regular `div` props such as `className`, `style`, and `data-*`.
+
+## Use the Legacy Pixi Background
+
+```tsx
+import { BackgroundRender, PixiRenderer } from "@applemusic-like-lyrics/react";
+
+<BackgroundRender album="/cover.jpg" renderer={PixiRenderer} />;
+```
+
+`PixiRenderer` requires the Core Pixi peer dependencies. The current default background uses `MeshGradientRenderer`, and cover resources are passed through `album`.
+
+## Ref
+
+```tsx
+import { useRef } from "react";
+import {
+    BackgroundRender,
+    type BackgroundRenderRef,
+} from "@applemusic-like-lyrics/react";
+
+const bgRef = useRef<BackgroundRenderRef>(null);
+
+<BackgroundRender ref={bgRef} album="/cover.jpg" />;
+```
+
+`BackgroundRenderRef` contains:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `bgRender` | `AbstractBaseRenderer \| undefined` | Underlying Core background instance |
+| `wrapperEl` | `HTMLDivElement \| null` | React wrapper DOM element |

--- a/packages/docs/src/content/docs/en/guides/react/introduction.mdx
+++ b/packages/docs/src/content/docs/en/guides/react/introduction.mdx
@@ -2,50 +2,44 @@
 title: AMLL for React Overview
 ---
 
-This package provides React bindings for AMLL components, so you can use AMLL lyrics components more conveniently in React projects.
+`@applemusic-like-lyrics/react` is the React binding for AMLL Core. It provides the `LyricPlayer` and `BackgroundRender` components, so React applications can drive lyric data, playback progress, playback state, and background resources through props.
 
-For core details, see [Core package README](https://github.com/amll-dev/applemusic-like-lyrics/tree/main/packages/core).
+The React binding does not parse lyric file formats. Use `@applemusic-like-lyrics/ttml` for TTML, and `@applemusic-like-lyrics/lyric` for other lyric formats.
 
 ## Installation
 
-Install peer dependencies if they are not already present:
-
-```bash
-npm install @pixi/app @pixi/core @pixi/display @pixi/filter-blur @pixi/filter-bulge-pinch @pixi/filter-color-matrix @pixi/sprite jss jss-preset-default
-# or
-yarn add @pixi/app @pixi/core @pixi/display @pixi/filter-blur @pixi/filter-bulge-pinch @pixi/filter-color-matrix @pixi/sprite jss jss-preset-default
+```sh
+npm install @applemusic-like-lyrics/react @applemusic-like-lyrics/ttml react react-dom
+npm install @pixi/app @pixi/core @pixi/display @pixi/filter-blur @pixi/filter-bulge-pinch @pixi/filter-color-matrix @pixi/sprite
 ```
 
-Install React dependencies (if needed):
+If you use pnpm or Yarn, replace `npm install` with `pnpm add` or `yarn add`.
 
-```bash
-npm install react react-dom
-# or
-yarn add react react-dom
-```
+Import the stylesheet from your app entry:
 
-Install AMLL React package:
-
-```bash
-npm install @applemusic-like-lyrics/react
-# or
-yarn add @applemusic-like-lyrics/react
+```ts
+import "@applemusic-like-lyrics/core/style.css";
 ```
 
 ## Usage Summary
 
-For detailed API docs, see [API Reference: React](/en/reference/react).
-
-A test example is available in repository playground:
-
-`packages/playground/react`
-
 ```tsx
+import { useState } from "react";
+import type { LyricLine } from "@applemusic-like-lyrics/core";
 import { LyricPlayer } from "@applemusic-like-lyrics/react";
 
-const App = () => {
+export function App() {
     const [currentTime, setCurrentTime] = useState(0);
     const [lyricLines, setLyricLines] = useState<LyricLine[]>([]);
-    return <LyricPlayer lyricLines={lyricLines} currentTime={currentTime} />;
-};
+
+    return (
+        <LyricPlayer
+            lyricLines={lyricLines}
+            currentTime={currentTime}
+            playing={true}
+        />
+    );
+}
 ```
+
+See [React Quick Start](./quick-start) for a complete audio-sync example, and [LyricPlayer Component](./lyric-player) / [BackgroundRender Component](./bg-render) for component props.

--- a/packages/docs/src/content/docs/en/guides/react/lyric-player.mdx
+++ b/packages/docs/src/content/docs/en/guides/react/lyric-player.mdx
@@ -2,37 +2,82 @@
 title: LyricPlayer Component
 ---
 
-## Overview
+`LyricPlayer` is AMLL's lyric performance component. It handles lyric scrolling, word highlighting, interlude dots, translations, romanization, background vocals, and duet layout. The React binding creates and owns the Core player instance; application code passes lyric data and playback state through props.
 
-`LyricPlayer` is one of AMLL core components. Lyric rendering effects (scrolling, word highlighting, glow, etc.) are handled by this component.
+## Basic Usage
 
-AMLL provides React bindings for `LyricPlayer`, so it can be used directly in React projects.
+```tsx
+import type { LyricLine } from "@applemusic-like-lyrics/core";
+import { LyricPlayer } from "@applemusic-like-lyrics/react";
+import "@applemusic-like-lyrics/core/style.css";
 
-For a quick setup, see [AMLL React Quick Start](./quick-start).
+export function Lyrics({
+    lyricLines,
+    currentTime,
+    playing,
+}: {
+    lyricLines: LyricLine[];
+    currentTime: number;
+    playing: boolean;
+}) {
+    return (
+        <LyricPlayer
+            lyricLines={lyricLines}
+            currentTime={currentTime}
+            playing={playing}
+            style={{ height: 480 }}
+        />
+    );
+}
+```
 
-## Usage
-
-Please refer to [AMLL React Quick Start](./quick-start).
+`currentTime` must be integer milliseconds. The React binding calls the underlying Core instance's `update()` every frame, so normal usage does not need manual animation updates.
 
 ## Props
 
-`LyricPlayer` is configurable through React props.
-
 | Prop | Type | Default | Description |
 | --- | --- | --- | --- |
-| `disabled` | `boolean` | `true` | Whether to disable part of the visual effects (currently mainly interlude marker animation) |
-| `playing` | `boolean` | `true` | Playback state; affects effect playback (for example interlude marker animation) |
-| `alignAnchor` | `top` / `bottom` / `center` | `center` | Alignment anchor for target lyric line |
-| `alignPosition` | `number` | `0.5` | Default line alignment position in component height (`0.0-1.0`) |
-| `enableSpring` | `boolean` | `true` | Use physics spring animation for lyric motion. Disabled mode falls back to transition-based behavior with lower effect richness but better low-end performance. |
-| `enableBlur` | `boolean` | `true` | Enable lyric line blur effect |
-| `enableScale` | `boolean` | `true` | Enable scale animation effect |
+| `disabled` | `boolean` | `false` | Disable the component's internal per-frame `update()` loop; when enabled, update the Core instance through a ref yourself |
+| `playing` | `boolean` | `true` | Playback state, used to play/pause effects such as interlude dots |
+| `lyricLines` | `LyricLine[]` | `[]` | Current lyric data. Do not mutate the array or objects after passing them in |
+| `currentTime` | `number` | `0` | Current playback position in integer milliseconds |
+| `isSeeking` | `boolean` | `false` | Marks the current progress change as a seek/jump so layout can align immediately |
+| `alignAnchor` | `"top" \| "bottom" \| "center"` | Core default | Align the target lyric line by top, bottom, or center |
+| `alignPosition` | `number` | Core default | Target lyric alignment position within component height, usually `0.0` to `1.0` |
+| `enableSpring` | `boolean` | `true` | Enable spring animation; disable on low-end devices to fall back to transition-based motion |
+| `enableBlur` | `boolean` | `true` | Enable blur on non-current lyric lines |
+| `enableScale` | `boolean` | `true` | Enable scale effect on non-current lyric lines |
 | `hidePassedLines` | `boolean` | `false` | Hide already-played lyric lines |
-| `lyricLines` | `LyricLine[]` | `null` | Lyric data. Do not mutate objects in this array after passing them in. |
-| `currentTime` | `number` | `null` | Current playback position in integer milliseconds. Higher update frequency gives better accuracy. |
-| `linePosXSpringParams` | `Partial[spring.SpringParams]` | `null` | Spring params for lyric line X-axis motion |
-| `linePosYSpringParams` | `Partial[spring.SpringParams]` | `null` | Spring params for lyric line Y-axis motion |
-| `lineScaleSpringParams` | `Partial[spring.SpringParams]` | `null` | Spring params for lyric line scale animation |
-| `bottomLine` | `ReactNode` | `null` | Custom content in bottom bar area (for example songwriter info) |
-| `onLyricLineClick` | `(line: LyricLineMouseEvent) => void` | `null` | Triggered when a lyric line is left-clicked |
-| `onLyricLineContextMenu` | `(line: LyricLineMouseEvent) => void` | `null` | Triggered when a lyric line is right-clicked |
+| `wordFadeWidth` | `number` | `0.5` | Word highlight fade width, in main lyric font-size units; must not be `0` |
+| `maskObsceneWordsMode` | `MaskObsceneWordsMode` | `Disabled` | Obscene-word masking mode |
+| `maskObsceneWordChar` | `string` | `"*"` | Mask character for obscene words; only the first character is used |
+| `optimizeOptions` | `OptimizeLyricOptions` | `{}` | Lyric preprocessing options; changes apply when lyrics are set again |
+| `linePosXSpringParams` | `Partial<spring.SpringParams>` | `undefined` | X-axis motion spring params; the Core method is marked for future removal |
+| `linePosYSpringParams` | `Partial<spring.SpringParams>` | `undefined` | Y-axis motion spring params |
+| `lineScaleSpringParams` | `Partial<spring.SpringParams>` | `undefined` | Scale animation spring params |
+| `bottomLine` | `ReactNode` | `undefined` | Custom content rendered into the fixed bottom area |
+| `lyricPlayer` | `new () => LyricPlayerBase` | default DOM player | Replace the underlying Core player implementation |
+| `onLyricLineClick` | `(event: LyricLineMouseEvent) => void` | `undefined` | Fired when a lyric line is left-clicked |
+| `onLyricLineContextMenu` | `(event: LyricLineMouseEvent) => void` | `undefined` | Fired when a lyric line is right-clicked |
+
+The component also accepts regular `div` props such as `className`, `style`, and `data-*`.
+
+## Ref
+
+```tsx
+import { useRef } from "react";
+import { LyricPlayer, type LyricPlayerRef } from "@applemusic-like-lyrics/react";
+
+const playerRef = useRef<LyricPlayerRef>(null);
+
+<LyricPlayer ref={playerRef} />;
+```
+
+`LyricPlayerRef` contains:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `lyricPlayer` | `LyricPlayerBase \| undefined` | Underlying Core player instance |
+| `wrapperEl` | `HTMLDivElement \| null` | React wrapper DOM element |
+
+Use the ref only when you need to call lower-level Core methods, access the bottom-line element, or manually update animation in `disabled` mode.

--- a/packages/docs/src/content/docs/en/guides/react/quick-start.mdx
+++ b/packages/docs/src/content/docs/en/guides/react/quick-start.mdx
@@ -2,180 +2,163 @@
 title: Quick Start
 ---
 
-## Overview
+import { Tabs, TabItem } from "@astrojs/starlight/components";
 
-In this guide, you will learn how to use AMLL core components in a React project.
+This guide shows how to use AMLL lyric and background components in React. The React package wraps Core instances as React components; lyric data is still Core `LyricLine[]`, and TTML should be parsed with `@applemusic-like-lyrics/ttml`.
 
-This quick start focuses on AMLL core usage. Some extra features may depend on additional packages.
+## Install
 
-> Currently AMLL mainly provides React bindings for core components. Additional player-page components are provided separately (for example in `react-full`).
+<Tabs syncKey="pkg">
+<TabItem label="npm">
 
-## Preparation
-
-### 1. Create a React project
-
-You can create a React project in multiple ways. Any modern setup works (for example Vite, Create React App, Next.js app router/client components, etc.).
-
-### 2. Install AMLL and dependencies
-
-Install peer dependencies (if not already installed):
-
-```bash
-npm install @pixi/app @pixi/core @pixi/display @pixi/filter-blur @pixi/filter-bulge-pinch @pixi/filter-color-matrix @pixi/sprite jss jss-preset-default
-# or
-yarn add @pixi/app @pixi/core @pixi/display @pixi/filter-blur @pixi/filter-bulge-pinch @pixi/filter-color-matrix @pixi/sprite jss jss-preset-default
+```sh
+npm install @applemusic-like-lyrics/react @applemusic-like-lyrics/ttml react react-dom
+npm install @pixi/app @pixi/core @pixi/display @pixi/filter-blur @pixi/filter-bulge-pinch @pixi/filter-color-matrix @pixi/sprite
 ```
 
-Install React runtime dependencies (if needed):
+</TabItem>
 
-```bash
-npm install react react-dom
-# or
-yarn add react react-dom
+<TabItem label="pnpm">
+
+```sh
+pnpm add @applemusic-like-lyrics/react @applemusic-like-lyrics/ttml react react-dom
+pnpm add @pixi/app @pixi/core @pixi/display @pixi/filter-blur @pixi/filter-bulge-pinch @pixi/filter-color-matrix @pixi/sprite
 ```
 
-Install AMLL React package:
+</TabItem>
 
-```bash
-npm install @applemusic-like-lyrics/react
-# or
-yarn add @applemusic-like-lyrics/react
+<TabItem label="Yarn">
+
+```sh
+yarn add @applemusic-like-lyrics/react @applemusic-like-lyrics/ttml react react-dom
+yarn add @pixi/app @pixi/core @pixi/display @pixi/filter-blur @pixi/filter-bulge-pinch @pixi/filter-color-matrix @pixi/sprite
 ```
 
-Now your project is ready to use AMLL in React.
+</TabItem>
+</Tabs>
 
-## Start Using AMLL
+Import the Core stylesheet from your app entry or component file:
 
-### 1. Use AMLL LyricPlayer in React
+```ts
+import "@applemusic-like-lyrics/core/style.css";
+```
 
-`LyricPlayer` is one of AMLL core components and provides lyric rendering.
+## Lyric Component
 
-Import with:
+`LyricPlayer` receives lyric data, playback progress, and playback state through props. The TTML-to-player data flow is:
 
-```jsx
+```ts
+const lyricLines = parseTTML(ttmlText).lines;
+```
+
+Complete example:
+
+```tsx
+import { useEffect, useRef, useState } from "react";
+import type { LyricLine } from "@applemusic-like-lyrics/core";
 import { LyricPlayer } from "@applemusic-like-lyrics/react";
-```
+import { parseTTML } from "@applemusic-like-lyrics/ttml";
+import "@applemusic-like-lyrics/core/style.css";
 
-Then you can render `<LyricPlayer />`.
+export default function App() {
+    const audioRef = useRef<HTMLAudioElement>(null);
+    const [lyricLines, setLyricLines] = useState<LyricLine[]>([]);
+    const [currentTime, setCurrentTime] = useState(0);
+    const [playing, setPlaying] = useState(false);
 
-Basic example:
+    useEffect(() => {
+        let canceled = false;
 
-```jsx
-import React from "react";
-import { LyricPlayer } from "@applemusic-like-lyrics/react";
+        async function loadLyric() {
+            const ttmlText = await fetch("/lyrics.ttml").then((res) => res.text());
+            if (!canceled) setLyricLines(parseTTML(ttmlText).lines);
+        }
 
-function App() {
-  return <LyricPlayer />;
-}
+        loadLyric();
+        return () => {
+            canceled = true;
+        };
+    }, []);
 
-export default App;
-```
+    useEffect(() => {
+        if (!playing) return;
 
-At this point no lyrics are shown yet. You need to provide props and update current playback time frame-by-frame.
+        let frameId = 0;
+        const updateProgress = () => {
+            const audio = audioRef.current;
+            if (audio && !audio.paused) {
+                setCurrentTime(Math.floor(audio.currentTime * 1000));
+                frameId = requestAnimationFrame(updateProgress);
+            }
+        };
 
-A more complete example:
+        frameId = requestAnimationFrame(updateProgress);
+        return () => cancelAnimationFrame(frameId);
+    }, [playing]);
 
-```jsx
-import React, { useState } from "react";
-import { LyricPlayer } from "@applemusic-like-lyrics/react";
-import { parseTTML } from "@applemusic-like-lyrics/core";
-
-const [currentTime, setCurrentTime] = useState(0);
-const [lyricLines, setLyricLines] = useState(0);
-const audio = document.getElementById("amll-audio");
-
-const parsedResult = parseTTML("TTML-Lyrics-Text");
-setLyricLines(parsedResult);
-
-let lastTime = -1;
-const frame = (time) => {
-    if (lastTime === -1) {
-        lastTime = time;
+    function syncAfterSeek() {
+        const audio = audioRef.current;
+        if (audio) setCurrentTime(Math.floor(audio.currentTime * 1000));
     }
-    if (!audio.paused) {
-        const time = (audio.currentTime * 1000) | 0;
-        setCurrentTime(time);
-    }
-    lastTime = time;
-    requestAnimationFrame(frame);
-};
-requestAnimationFrame(frame);
 
-function App() {
     return (
-        <>
-            <audio id="amll-audio" src="Audio-Music-Src" controls />
-            <LyricPlayer lyricLines={lyricLines} currentTime={currentTime} />
-        </>
-    );
-}
-export default App;
-```
-
-This setup includes:
-
-- an `<audio>` element for playback
-- `useState` state for lyric data and playback time
-- `requestAnimationFrame` loop to update `currentTime`
-- TTML parsing via `parseTTML`
-
-> Note: recommended long-term usage is importing TTML handling from `@applemusic-like-lyrics/ttml` for dedicated TTML workflows.
-
-### 2. Use BackgroundRender in React
-
-`BackgroundRender` is another AMLL core component for animated/static playback backgrounds.
-
-In this example, `EplorRenderer` is used.
-
-```jsx
-import React, { useState } from "react";
-import { LyricPlayer, BackgroundRender } from "@applemusic-like-lyrics/react";
-import { EplorRenderer, parseTTML } from "@applemusic-like-lyrics/core";
-
-const [currentTime, setCurrentTime] = useState(0);
-const [lyricLines, setLyricLines] = useState(0);
-const [albumUrl, setAlbumUrl] = useState("");
-const audio = document.getElementById("amll-audio");
-
-const parsedResult = parseTTML("TTML-Lyrics-Text");
-setLyricLines(parsedResult);
-setAlbumUrl("Album-Pic-Url");
-
-let lastTime = -1;
-const frame = (time) => {
-    if (lastTime === -1) {
-        lastTime = time;
-    }
-    if (!audio.paused) {
-        const time = (audio.currentTime * 1000) | 0;
-        setCurrentTime(time);
-    }
-    lastTime = time;
-    requestAnimationFrame(frame);
-};
-requestAnimationFrame(frame);
-
-function App() {
-    return (
-        <>
-            <audio id="amll-audio" src="Audio-Music-Src" controls />
-            <BackgroundRender
-                albumImageUrl={albumUrl}
-                renderer={EplorRenderer}
+        <main style={{ height: "100vh" }}>
+            <audio
+                ref={audioRef}
+                src="/song.mp3"
+                controls
+                onPlay={() => setPlaying(true)}
+                onPause={() => setPlaying(false)}
+                onSeeked={syncAfterSeek}
             />
-            <LyricPlayer lyricLines={lyricLines} currentTime={currentTime} />
-        </>
+            <LyricPlayer
+                lyricLines={lyricLines}
+                currentTime={currentTime}
+                playing={playing}
+                style={{ height: "calc(100vh - 48px)" }}
+            />
+        </main>
     );
 }
-export default App;
 ```
 
-With `<BackgroundRender />`, pass `albumImageUrl` and choose a renderer (for example `EplorRenderer`) to get animated backgrounds.
+Application code converts audio progress to integer milliseconds and passes it to `currentTime`. The React binding already calls Core `update()` internally every frame, so do not call it again in normal usage.
 
-## Wrap-up
+## Background Component
 
-You have completed a quick AMLL React integration flow. For more options and props, continue with:
+`BackgroundRender` receives cover artwork through `album`, which may be an image URL, video URL, `HTMLImageElement`, or `HTMLVideoElement`. The default renderer is `MeshGradientRenderer`; pass `PixiRenderer` explicitly if you need the legacy Pixi background.
 
-- [LyricPlayer Component](./lyric-player)
-- [BackgroundRender Component](./bg-render)
-- [API Reference: React](/en/reference/react)
+```tsx
+import type { LyricLine } from "@applemusic-like-lyrics/core";
+import { BackgroundRender, LyricPlayer } from "@applemusic-like-lyrics/react";
+
+export function PlayerView({
+    albumUrl,
+    lyricLines,
+    currentTime,
+    playing,
+}: {
+    albumUrl: string;
+    lyricLines: LyricLine[];
+    currentTime: number;
+    playing: boolean;
+}) {
+    return (
+        <div style={{ position: "relative", height: "100vh", overflow: "hidden" }}>
+            <BackgroundRender
+                album={albumUrl}
+                playing={playing}
+                style={{ position: "absolute", inset: 0 }}
+            />
+            <LyricPlayer
+                lyricLines={lyricLines}
+                currentTime={currentTime}
+                playing={playing}
+                style={{ position: "absolute", inset: 0 }}
+            />
+        </div>
+    );
+}
+```
+
+For more options, see [LyricPlayer Component](./lyric-player), [BackgroundRender Component](./bg-render), and [React API Reference](/en/reference/react).

--- a/packages/docs/src/content/docs/guides/overview/quickstart.mdx
+++ b/packages/docs/src/content/docs/guides/overview/quickstart.mdx
@@ -9,126 +9,38 @@ import {
     TabItem,
 } from "@astrojs/starlight/components";
 
-下面快速介绍如何将 AMLL 歌词组件集成到你的项目中。请注意，AMLL 不提供 CDN 引入方式，必须使用 bundler。
+AMLL 不提供 CDN 版本，需要在 Vite、Webpack、Rspack、Next.js 客户端组件等 bundler 环境中使用。本文只介绍渲染组件的最小接入方式；歌词格式解析、TTML 生成等工具包请参考 [歌词格式快速开始](/guides/lyric/quickstart) 和 [API 参考](/reference)。
 
-有关除组件库之外的其他周围工具包，请直接查阅 [API 参考](/reference)。
-
-## 依赖
-
-安装 AMLL 核心库：
-
-<Tabs syncKey="pkg">
-<TabItem label="npm">
-
-```sh
-npm install @applemusic-like-lyrics/core
-```
-
-</TabItem>
-
-<TabItem label="pnpm">
-
-```sh
-pnpm add @applemusic-like-lyrics/core
-```
-
-</TabItem>
-
-<TabItem label="Yarn">
-
-```sh
-yarn add @applemusic-like-lyrics/core
-```
-
-</TabItem>
-</Tabs>
-
-此外，AMLL 将一些图形与动画库声明为 peer，这是为了复用项目中可能存在的相关依赖。一些包管理器或配置下可能会自动安装 peer，若没有，需要手动安装。
-
-<Tabs syncKey="pkg">
-<TabItem label="npm">
-
-```sh
-npm install @pixi/app @pixi/core @pixi/display @pixi/filter-blur @pixi/filter-bulge-pinch @pixi/filter-color-matrix @pixi/sprite jss jss-preset-default
-```
-
-</TabItem>
-
-<TabItem label="pnpm">
-
-```sh
-pnpm add @pixi/app @pixi/core @pixi/display @pixi/filter-blur @pixi/filter-bulge-pinch @pixi/filter-color-matrix @pixi/sprite jss jss-preset-default
-```
-
-</TabItem>
-
-<TabItem label="Yarn">
-
-```sh
-yarn add @pixi/app @pixi/core @pixi/display @pixi/filter-blur @pixi/filter-bulge-pinch @pixi/filter-color-matrix @pixi/sprite jss jss-preset-default
-```
-
-</TabItem>
-</Tabs>
-
-接下来你可以使用原生包，也可以使用 React 或 Vue 绑定。
+## 选择入口
 
 <CardGrid>
     <LinkCard
-        title="使用 Vanilla 方式引入"
-        description="不使用前端框架"
-        href="#使用-vanilla-方式引入"
+        title="Core 原生 DOM"
+        description="不依赖 React/Vue，直接操作组件实例"
+        href="#core-原生-dom"
     />
     <LinkCard
-        title="使用 React 绑定"
-        description="项目使用 React 框架"
-        href="#使用-react-绑定"
+        title="React 绑定"
+        description="在 React 应用中通过组件 props 驱动"
+        href="#react-绑定"
     />
     <LinkCard
-        title="使用 Vue 绑定"
-        description="项目使用 Vue 框架"
-        href="#使用-vue-绑定"
+        title="Vue 绑定"
+        description="在 Vue 应用中通过响应式 props 驱动"
+        href="#vue-绑定"
     />
 </CardGrid>
 
-## 使用 Vanilla 方式引入
+## 安装依赖
 
-AMLL 核心库是框架无关的。无论是否使用框架，均可使用此方法引入。
-
-```js
-import { LyricPlayer } from "@applemusic-like-lyrics/core";
-
-// 创建歌词播放组件
-const player = new LyricPlayer();
-
-// 将组件的元素添加到页面
-document.body.appendChild(player.getElement());
-
-// 设置歌词
-player.setLyricLines([]);
-
-// 设定当前播放时间
-player.setCurrentTime(0);
-
-// 更新歌词组件动画
-player.update(0);
-```
-
-其中的 [`setLyricLines`](/reference/core/classlyricplayerbase#setlyriclines) 方法接受 [`LyricLine`](/reference/core/interfacelyricline) 类型的对象。在传入之后不应再修改这一对象的属性，否则可能导致问题。
-
-[`setCurrentTime`](/reference/core/classlyricplayerbase#setcurrenttime) 方法与 [`update`](/reference/core/classlyricplayerbase#update) 方法接受当前播放进度（整数，单位毫秒）作为参数，**在播放时需要逐帧调用**。此外在每次 `setLyricLines` 之后也应调用一次 `update` 以更新内容。
-
-你可以前往 [API 参考：Core 核心](/reference/core) 获取详细的接口文档。
-
-## 使用 React 绑定
-
-确保你已安装 `react` 和 `react-dom` 包。然后安装 AMLL React 绑定包：
+核心渲染包使用 Pixi 相关包作为 peer 依赖。npm 7+、pnpm、Yarn Berry 等环境通常会自动处理 peer；如果你的包管理器没有自动安装，或构建时报缺少 `@pixi/*` 包，请按下面的命令手动安装。
 
 <Tabs syncKey="pkg">
 <TabItem label="npm">
 
 ```sh
-npm install @applemusic-like-lyrics/react
+npm install @applemusic-like-lyrics/core @applemusic-like-lyrics/ttml
+npm install @pixi/app @pixi/core @pixi/display @pixi/filter-blur @pixi/filter-bulge-pinch @pixi/filter-color-matrix @pixi/sprite
 ```
 
 </TabItem>
@@ -136,7 +48,8 @@ npm install @applemusic-like-lyrics/react
 <TabItem label="pnpm">
 
 ```sh
-pnpm add @applemusic-like-lyrics/react
+pnpm add @applemusic-like-lyrics/core @applemusic-like-lyrics/ttml
+pnpm add @pixi/app @pixi/core @pixi/display @pixi/filter-blur @pixi/filter-bulge-pinch @pixi/filter-color-matrix @pixi/sprite
 ```
 
 </TabItem>
@@ -144,65 +57,182 @@ pnpm add @applemusic-like-lyrics/react
 <TabItem label="Yarn">
 
 ```sh
-yarn add @applemusic-like-lyrics/react
+yarn add @applemusic-like-lyrics/core @applemusic-like-lyrics/ttml
+yarn add @pixi/app @pixi/core @pixi/display @pixi/filter-blur @pixi/filter-bulge-pinch @pixi/filter-color-matrix @pixi/sprite
 ```
 
 </TabItem>
 </Tabs>
 
-React 绑定包拥有具名导出 [`LyricPlayer`](/reference/react/variablelyricplayer) 作为核心组件。下面是一段示例。
+`@applemusic-like-lyrics/ttml` 用于把 TTML 文本解析成 AMLL 播放器可直接使用的 `LyricLine[]`：`parseTTML(ttmlText).lines`。
 
-```jsx
-import React, { useState } from "react";
-import { LyricPlayer } from "@applemusic-like-lyrics/react";
-import { parseTTML } from "@applemusic-like-lyrics/core";
+所有使用 `LyricPlayer` 的入口都需要引入样式：
 
-const [currentTime, setCurrentTime] = useState(0);
-const [lyricLines, setLyricLines] = useState(0);
-const audio = document.getElementById("amll-audio"); // 获取 <audio> 元素
+```ts
+import "@applemusic-like-lyrics/core/style.css";
+```
 
-const parsedResult = parseTTML(`SomeTtmlText...`); // 对歌词进行处理
-setLyricLines(parsedResult); // 设置歌词
+## Core 原生 DOM
 
-let lastTime = -1;
-const frame = (time) => {
-    if (lastTime === -1) {
-        lastTime = time;
-    }
+Core 包适合不使用前端框架，或需要自己管理生命周期的场景。
+
+```ts
+import { LyricPlayer } from "@applemusic-like-lyrics/core";
+import { parseTTML } from "@applemusic-like-lyrics/ttml";
+import "@applemusic-like-lyrics/core/style.css";
+
+const audio = document.querySelector<HTMLAudioElement>("#audio")!;
+const container = document.querySelector<HTMLElement>("#lyrics")!;
+const player = new LyricPlayer();
+
+container.appendChild(player.getElement());
+
+const ttmlText = await fetch("/lyrics.ttml").then((res) => res.text());
+player.setLyricLines(parseTTML(ttmlText).lines);
+player.setCurrentTime(0, true);
+player.update(0);
+
+let frameId = 0;
+let lastFrameTime = -1;
+
+function frame(time: number) {
+    if (lastFrameTime === -1) lastFrameTime = time;
+
+    const delta = time - lastFrameTime;
+    lastFrameTime = time;
+
     if (!audio.paused) {
-        const time = (audio.currentTime * 1000) | 0;
-        setCurrentTime(time);
+        player.setCurrentTime(Math.floor(audio.currentTime * 1000));
     }
-    lastTime = time;
-    requestAnimationFrame(frame); // 逐帧调用
-};
-requestAnimationFrame(frame);
+    player.update(delta);
 
-function App() {
+    frameId = requestAnimationFrame(frame);
+}
+
+frameId = requestAnimationFrame(frame);
+
+window.addEventListener("beforeunload", () => {
+    cancelAnimationFrame(frameId);
+    player.dispose();
+});
+```
+
+要点：
+
+- `setLyricLines(lines, initialTime?)` 传入的是 AMLL Core 的 [`LyricLine[]`](/reference/core/interfacelyricline)，传入后不要再原地修改。
+- `setCurrentTime(ms, isSeek?)` 的时间单位是整数毫秒；用户拖动进度条或跳转歌词时，把第二个参数设为 `true`。
+- `update(deltaMs)` 负责推进动画，播放中应逐帧调用；`deltaMs` 是本帧距离上一帧的毫秒差。
+- 组件不用时调用 `dispose()` 释放 DOM、监听器和渲染资源。
+
+## React 绑定
+
+React 项目安装绑定包和 React 运行时：
+
+<Tabs syncKey="pkg">
+<TabItem label="npm">
+
+```sh
+npm install @applemusic-like-lyrics/react @applemusic-like-lyrics/ttml react react-dom
+```
+
+</TabItem>
+
+<TabItem label="pnpm">
+
+```sh
+pnpm add @applemusic-like-lyrics/react @applemusic-like-lyrics/ttml react react-dom
+```
+
+</TabItem>
+
+<TabItem label="Yarn">
+
+```sh
+yarn add @applemusic-like-lyrics/react @applemusic-like-lyrics/ttml react react-dom
+```
+
+</TabItem>
+</Tabs>
+
+`@applemusic-like-lyrics/react` 依赖 `@applemusic-like-lyrics/core`，因此仍需要满足 Core 的 Pixi peer 依赖，并引入 Core 样式。
+
+```tsx
+import { useEffect, useRef, useState } from "react";
+import type { LyricLine } from "@applemusic-like-lyrics/core";
+import { LyricPlayer } from "@applemusic-like-lyrics/react";
+import { parseTTML } from "@applemusic-like-lyrics/ttml";
+import "@applemusic-like-lyrics/core/style.css";
+
+export function App() {
+    const audioRef = useRef<HTMLAudioElement>(null);
+    const [lyricLines, setLyricLines] = useState<LyricLine[]>([]);
+    const [currentTime, setCurrentTime] = useState(0);
+    const [playing, setPlaying] = useState(false);
+
+    useEffect(() => {
+        let canceled = false;
+        fetch("/lyrics.ttml")
+            .then((res) => res.text())
+            .then((text) => {
+                if (!canceled) setLyricLines(parseTTML(text).lines);
+            });
+
+        return () => {
+            canceled = true;
+        };
+    }, []);
+
+    useEffect(() => {
+        if (!playing) return;
+
+        let frameId = 0;
+        const frame = () => {
+            const audio = audioRef.current;
+            if (audio && !audio.paused) {
+                setCurrentTime(Math.floor(audio.currentTime * 1000));
+                frameId = requestAnimationFrame(frame);
+            }
+        };
+
+        frameId = requestAnimationFrame(frame);
+        return () => cancelAnimationFrame(frameId);
+    }, [playing]);
+
     return (
         <>
-            <audio id="amll-audio" src="Audio-Music-Src" controls />
+            <audio
+                ref={audioRef}
+                src="/song.mp3"
+                controls
+                onPlay={() => setPlaying(true)}
+                onPause={() => setPlaying(false)}
+                onSeeked={() => {
+                    const audio = audioRef.current;
+                    if (audio) setCurrentTime(Math.floor(audio.currentTime * 1000));
+                }}
+            />
             <LyricPlayer
-                lyricLines={lyricLines} // 设置歌词
-                currentTime={currentTime} // 通过逐帧调用函数，设置播放时间
+                lyricLines={lyricLines}
+                currentTime={currentTime}
+                playing={playing}
+                style={{ height: 480 }}
             />
         </>
     );
 }
-export default App;
 ```
 
-你可以前往 [API 参考：React 绑定](/reference/react) 获取详细的接口文档。
+React 绑定会在组件内部逐帧调用 Core 的 `update()`；应用侧只需要让 `currentTime` 跟随音频播放进度更新，并让 `playing` 反映当前播放状态。
 
-## 使用 Vue 绑定
+## Vue 绑定
 
-确保你已安装 Vue。然后安装 AMLL Vue 绑定包：
+Vue 项目安装绑定包和 Vue：
 
 <Tabs syncKey="pkg">
 <TabItem label="npm">
 
 ```sh
-npm install @applemusic-like-lyrics/vue
+npm install @applemusic-like-lyrics/vue @applemusic-like-lyrics/ttml vue
 ```
 
 </TabItem>
@@ -210,7 +240,7 @@ npm install @applemusic-like-lyrics/vue
 <TabItem label="pnpm">
 
 ```sh
-pnpm add @applemusic-like-lyrics/vue
+pnpm add @applemusic-like-lyrics/vue @applemusic-like-lyrics/ttml vue
 ```
 
 </TabItem>
@@ -218,122 +248,66 @@ pnpm add @applemusic-like-lyrics/vue
 <TabItem label="Yarn">
 
 ```sh
-yarn add @applemusic-like-lyrics/vue
+yarn add @applemusic-like-lyrics/vue @applemusic-like-lyrics/ttml vue
 ```
 
 </TabItem>
 </Tabs>
 
-Vue 绑定包拥有具名导出 [`LyricPlayer`](/reference/vue/classlyricplayer) 作为核心组件。歌词对象、播放进度等均以组件的响应式属性传入。下面是一段示例代码。
-
-<Tabs syncKey="vapi">
-<TabItem label="组合式">
+`@applemusic-like-lyrics/vue` 依赖 `@applemusic-like-lyrics/core`，因此仍需要满足 Core 的 Pixi peer 依赖，并引入 Core 样式。
 
 ```vue
 <template>
-    <LyricPlayer
-        :lyric-lines="amllLyricLines"
-        :current-time="progressRef"
-        :playing="playingRef"
+    <audio
+        ref="audioRef"
+        src="/song.mp3"
+        controls
+        @play="onPlay"
+        @pause="playing = false"
+        @seeked="syncCurrentTime"
     />
-    <audio src="..." ref="audioElRef"></audio>
+    <LyricPlayer
+        :lyric-lines="lyricLines"
+        :current-time="currentTime"
+        :playing="playing"
+        style="height: 480px"
+    />
 </template>
 
 <script setup lang="ts">
-import { onMounted, ref, useTemplateRef } from "vue";
 import type { LyricLine } from "@applemusic-like-lyrics/core";
 import { LyricPlayer } from "@applemusic-like-lyrics/vue";
-
+import { parseTTML } from "@applemusic-like-lyrics/ttml";
+import { onMounted, ref, shallowRef } from "vue";
 import "@applemusic-like-lyrics/core/style.css";
 
-const amllLyricLines: LyricLine[] = [];
+const audioRef = ref<HTMLAudioElement>();
+const lyricLines = shallowRef<LyricLine[]>([]);
+const currentTime = ref(0);
+const playing = ref(false);
 
-const progressRef = ref(0);
-const playingRef = ref(false);
+onMounted(async () => {
+    const ttmlText = await fetch("/lyrics.ttml").then((res) => res.text());
+    lyricLines.value = parseTTML(ttmlText).lines;
+});
 
-const audioElRef = useTemplateRef("audioElRef");
-
-function onFrame() {
-    if (audioElRef.value)
-        progressRef.value = Math.round(audioElRef.value.currentTime * 1000);
-    if (playingRef.value) requestAnimationFrame(onFrame);
+function syncCurrentTime() {
+    const audio = audioRef.value;
+    if (audio) currentTime.value = Math.floor(audio.currentTime * 1000);
 }
 
-onMounted(() => {
-    if (!audioElRef.value) return;
-    audioElRef.value.addEventListener("play", () => {
-        playingRef.value = true;
-        requestAnimationFrame(onFrame);
-    });
-    audioElRef.value.addEventListener("pause", () => {
-        playingRef.value = false;
-    });
-});
+function onPlay() {
+    playing.value = true;
+
+    const frame = () => {
+        if (!playing.value) return;
+        syncCurrentTime();
+        requestAnimationFrame(frame);
+    };
+
+    requestAnimationFrame(frame);
+}
 </script>
 ```
 
-</TabItem>
-
-<TabItem label="选项式">
-
-```vue
-<template>
-    <LyricPlayer
-        :lyric-lines="amllLyricLines"
-        :current-time="progressRef"
-        :playing="playingRef"
-    />
-    <audio src="..." ref="audioElRef"></audio>
-</template>
-
-<script lang="ts">
-import { defineComponent } from "vue";
-import type { LyricLine } from "@applemusic-like-lyrics/core";
-import { LyricPlayer } from "@applemusic-like-lyrics/vue";
-
-import "@applemusic-like-lyrics/core/style.css";
-
-export default defineComponent({
-    components: {
-        LyricPlayer,
-    },
-    data() {
-        return {
-            amllLyricLines: [] as LyricLine[],
-            progressRef: 0,
-            playingRef: false,
-        };
-    },
-    mounted() {
-        const audioEl = this.$refs.audioElRef as HTMLAudioElement | null;
-        if (!audioEl) return;
-
-        audioEl.addEventListener("play", () => {
-            this.playingRef = true;
-            this.onFrame();
-        });
-
-        audioEl.addEventListener("pause", () => {
-            this.playingRef = false;
-        });
-    },
-    methods: {
-        onFrame() {
-            const audioEl = this.$refs.audioElRef as HTMLAudioElement | null;
-            if (audioEl) {
-                this.progressRef = Math.round(audioEl.currentTime * 1000);
-            }
-
-            if (this.playingRef) {
-                requestAnimationFrame(this.onFrame);
-            }
-        },
-    },
-});
-</script>
-```
-
-</TabItem>
-</Tabs>
-
-你可以前往 [API 参考：Vue 绑定](/reference/vue) 获取详细的接口文档。
+Vue 绑定同样会在组件内部逐帧推进动画；应用侧只需要通过响应式属性传入歌词、整数毫秒进度和播放状态。

--- a/packages/docs/src/content/docs/guides/react/bg-render.mdx
+++ b/packages/docs/src/content/docs/guides/react/bg-render.mdx
@@ -2,32 +2,77 @@
 title: BackgroundRender 组件
 ---
 
-## 概述
+`BackgroundRender` 是 AMLL 的动静态背景渲染组件。React 绑定默认使用 Core 的 `MeshGradientRenderer`，通过 `album` prop 接收封面图片或视频资源。
 
-bgRender是AMLL的核心组件之一。AMLL的动静态背景渲染由bgRender完成。
+## 基本用法
 
-AMLL对bgRender进行了React绑定，因此你可以方便的在React项目中使用bgRender。
+```tsx
+import { BackgroundRender } from "@applemusic-like-lyrics/react";
 
-bgRender的快速入门，你可以在[AMLL React快速入门](./quick-start)中找到。
+export function Background({ albumUrl, playing }: {
+    albumUrl: string;
+    playing: boolean;
+}) {
+    return (
+        <BackgroundRender
+            album={albumUrl}
+            playing={playing}
+            style={{ position: "absolute", inset: 0 }}
+        />
+    );
+}
+```
 
-## 使用
+如果传入的是视频 URL，请设置 `albumIsVideo`：
 
-请参考[AMLL React快速入门](./quick-start)中的教程。
+```tsx
+<BackgroundRender album="/cover-video.mp4" albumIsVideo />
+```
 
-## Props参数
+## Props
 
-AMLL bgRender已进行React绑定，通过Props即可进行自定义配置。
-
-bgRender提供以下Props：
-
-| Props | 类型 | 默认 | 作用 |
+| Prop | 类型 | 默认 | 作用 |
 | --- | --- | --- | --- |
-| albumImageUrl | 字符串 | true  | 设置背景专辑图片 |
-| fps | 数字 | 30  | 设置当前背景动画帧率 |
-| playing | 布尔值 | true | 设置当前播放状态 |
-| flowSpeed | 数字 | 2 | 设置当前动画流动速度 |
-| hasLyric | 布尔值 | true | 设置背景是否根据“是否有歌词”这个特征调整自身效果，例如有歌词时会变得更加活跃。部分渲染器会根据这个特征调整自身效果。如果不确定是否需要赋值或无法知晓是否包含歌词，请传入 true 或不做任何处理。 |
-| lowFreqVolume | 数字 | 1.0  | 设置低频的音量大小，范围在 80hz-120hz 之间为宜，取值范围在 0.0-1.0 之间。部分渲染器会根据音量大小调整背景效果（例如根据鼓点跳动）。如果无法获取到类似的数据，请传入 undefined 或 1.0 作为默认值，或不做任何处理。 |
-| renderScale | 数字 | 0.5 | 设置当前渲染缩放比例 |
-| staticMode | 布尔值 | false | 是否启用静态模式，即图片在更换后就会保持静止状态并禁用更新，以节省性能 |
-| renderer | Canvas | EplorRenderer | 设置渲染器。默认渲染器有可能会随着版本更新而更换。新版：EplorRenderer（真流体背景）；旧版：PixiRenderer |
+| `album` | `string \| HTMLImageElement \| HTMLVideoElement` | `undefined` | 背景专辑资源，可以是图片 URL、视频 URL、图片元素或视频元素 |
+| `albumIsVideo` | `boolean` | `false` | 当 `album` 是字符串且指向视频资源时设为 `true` |
+| `fps` | `number` | 渲染器默认 | 背景动画帧率；设为 `0` 可停止动画 |
+| `playing` | `boolean` | `true` | 当前播放状态，控制背景动画暂停或恢复 |
+| `flowSpeed` | `number` | 渲染器默认 | 背景流动速度 |
+| `hasLyric` | `boolean` | `true` | 是否按“有歌词”状态调整背景效果；不确定时保持默认 |
+| `lowFreqVolume` | `number` | 渲染器默认 | 低频音量提示，范围通常为 `0.0` 到 `1.0` |
+| `renderScale` | `number` | 渲染器默认 | 背景渲染缩放比例，降低可减少 GPU 压力 |
+| `staticMode` | `boolean` | `false` | 启用静态模式，切换资源后保持静止以节省性能 |
+| `renderer` | `new (canvas: HTMLCanvasElement) => BaseRenderer` | `MeshGradientRenderer` | 替换底层背景渲染器；可传入 `PixiRenderer` 使用旧版背景 |
+
+除上表外，组件也接受普通 `div` 属性，例如 `className`、`style` 和 `data-*`。
+
+## 使用旧版 Pixi 背景
+
+```tsx
+import { BackgroundRender, PixiRenderer } from "@applemusic-like-lyrics/react";
+
+<BackgroundRender album="/cover.jpg" renderer={PixiRenderer} />;
+```
+
+`PixiRenderer` 需要 Core 的 Pixi peer 依赖可用。当前默认背景使用 `MeshGradientRenderer`，封面资源统一通过 `album` 传入。
+
+## Ref
+
+```tsx
+import { useRef } from "react";
+import {
+    BackgroundRender,
+    type BackgroundRenderRef,
+} from "@applemusic-like-lyrics/react";
+
+const bgRef = useRef<BackgroundRenderRef>(null);
+
+<BackgroundRender ref={bgRef} album="/cover.jpg" />;
+```
+
+`BackgroundRenderRef` 包含：
+
+| 字段 | 类型 | 作用 |
+| --- | --- | --- |
+| `bgRender` | `AbstractBaseRenderer \| undefined` | 底层 Core 背景实例 |
+| `wrapperEl` | `HTMLDivElement \| null` | React 包装层 DOM |

--- a/packages/docs/src/content/docs/guides/react/introduction.mdx
+++ b/packages/docs/src/content/docs/guides/react/introduction.mdx
@@ -2,43 +2,44 @@
 title: AMLL for React 概述
 ---
 
-AMLL 组件库的 React 绑定，你可以通过此库来更加方便地使用 AMLL 歌词组件。
+`@applemusic-like-lyrics/react` 是 AMLL Core 的 React 绑定。它提供 `LyricPlayer` 和 `BackgroundRender` 两个主要组件，让 React 应用通过 props 管理歌词数据、播放进度、播放状态和背景资源。
 
-详情可以访问 [Core 核心组件的 README.md](../core/README.md)。
+React 绑定不负责解析歌词格式。TTML 推荐使用 `@applemusic-like-lyrics/ttml`，其他歌词格式使用 `@applemusic-like-lyrics/lyric`。
 
 ## 安装
 
-安装使用的依赖（如果以下列出的依赖包没有安装的话需要自行安装）：
-```bash
-npm install @pixi/app @pixi/core @pixi/display @pixi/filter-blur @pixi/filter-bulge-pinch @pixi/filter-color-matrix @pixi/sprite jss jss-preset-default # 使用 npm
-yarn add @pixi/app @pixi/core @pixi/display @pixi/filter-blur @pixi/filter-bulge-pinch @pixi/filter-color-matrix @pixi/sprite jss jss-preset-default # 使用 yarn
+```sh
+npm install @applemusic-like-lyrics/react @applemusic-like-lyrics/ttml react react-dom
+npm install @pixi/app @pixi/core @pixi/display @pixi/filter-blur @pixi/filter-bulge-pinch @pixi/filter-color-matrix @pixi/sprite
 ```
 
-安装 React 绑定需要使用的依赖（如果以下列出的依赖包没有安装的话需要自行安装）：
-```bash
-npm install react react-dom # 使用 npm
-yarn add react react-dom # 使用 yarn
+如果使用 pnpm 或 Yarn，将上面的 `npm install` 分别替换为 `pnpm add` 或 `yarn add`。
+
+在应用入口引入样式：
+
+```ts
+import "@applemusic-like-lyrics/core/style.css";
 ```
 
-安装本体框架：
-```bash
-npm install @applemusic-like-lyrics/react # 使用 npm
-yarn add @applemusic-like-lyrics/react # 使用 yarn
-```
-
-## 使用方式摘要
-
-详细的 API 文档请参考 [./docs/modules.md](./docs/modules.md)
-
-一个测试用途的程序可以在 [../../../playground/react/src/test.tsx](../../../playground/react/src/test.tsx) 里找到。
+## 使用摘要
 
 ```tsx
+import { useState } from "react";
+import type { LyricLine } from "@applemusic-like-lyrics/core";
 import { LyricPlayer } from "@applemusic-like-lyrics/react";
 
-const App = () => {
+export function App() {
     const [currentTime, setCurrentTime] = useState(0);
-	const [lyricLines, setLyricLines] = useState<LyricLine[]>([]);
-    return <LyricPlayer lyricLines={lyricLines} currentTime={currentTime} />
-};
+    const [lyricLines, setLyricLines] = useState<LyricLine[]>([]);
 
+    return (
+        <LyricPlayer
+            lyricLines={lyricLines}
+            currentTime={currentTime}
+            playing={true}
+        />
+    );
+}
 ```
+
+完整音频同步示例见 [React 快速入门](./quick-start)，组件属性见 [LyricPlayer 组件](./lyric-player) 和 [BackgroundRender 组件](./bg-render)。

--- a/packages/docs/src/content/docs/guides/react/lyric-player.mdx
+++ b/packages/docs/src/content/docs/guides/react/lyric-player.mdx
@@ -2,39 +2,82 @@
 title: LyricPlayer 组件
 ---
 
-## 概述
+`LyricPlayer` 是 AMLL 的歌词演出组件，负责歌词滚动、逐词高亮、间奏点、翻译、音译、背景人声和对唱布局。React 绑定会创建并维护 Core 播放器实例，应用侧通过 props 传入歌词数据和播放状态。
 
-LyricPlayer是AMLL的核心组件之一。AMLL的歌词演出（即歌词滚动、逐词歌词高亮、歌词辉光等效果）由LyricPlayer完成。
+## 基本用法
 
-AMLL对LyricPlayer进行了React绑定，因此你可以方便的在React项目中使用LyricPlayer。
+```tsx
+import type { LyricLine } from "@applemusic-like-lyrics/core";
+import { LyricPlayer } from "@applemusic-like-lyrics/react";
+import "@applemusic-like-lyrics/core/style.css";
 
-LyricPlayer的快速入门，你可以在[AMLL React快速入门](./quick-start)中找到。
+export function Lyrics({
+    lyricLines,
+    currentTime,
+    playing,
+}: {
+    lyricLines: LyricLine[];
+    currentTime: number;
+    playing: boolean;
+}) {
+    return (
+        <LyricPlayer
+            lyricLines={lyricLines}
+            currentTime={currentTime}
+            playing={playing}
+            style={{ height: 480 }}
+        />
+    );
+}
+```
 
-## 使用
+`currentTime` 必须是整数毫秒。React 绑定会自动逐帧调用内部 Core 实例的 `update()`，常规使用时不需要手动更新动画。
 
-请参考[AMLL React快速入门](./quick-start)中的教程。
+## Props
 
-## Props参数
-
-AMLL LyricPlayer已进行React绑定，通过Props即可进行自定义配置。
-
-Lyric Player提供以下Props：
-
-| Props | 类型 | 默认 | 作用 |
+| Prop | 类型 | 默认 | 作用 |
 | --- | --- | --- | --- |
-| disabled | 布尔值 | true  | 是否演出部分效果，目前会控制播放间奏点的动画的播放暂停与否 |
-| playing | 布尔值 | true | 是否演出部分效果，目前会控制播放间奏点的动画的播放暂停与否 |
-| alignAnchor | top/bottom/center | center | 设置歌词行的对齐方式，分别向目标歌词行的顶部/底部/垂直中心对齐|
-| alignPosition | 数字 | 0.5 | 设置默认的歌词行对齐位置，相对于整个歌词播放组件的大小位置。可以设置一个 0.0-1.0 之间的任意数字，代表组件高度由上到下的比例位置 |
-| enableSpring | 布尔值 | true | 设置是否使用物理弹簧算法实现歌词动画效果。如果启用，则会通过弹簧算法实时处理歌词位置，但是需要性能足够强劲的电脑方可流畅运行；如果不启用，则会回退到基于 `transition` 的过渡效果，对低性能的机器比较友好，但是效果会比较单一 |
-| enableBlur | 布尔值 | true | 设置是否启用歌词行的模糊效果 |
-| enableScale | 布尔值 | true | 设置是否使用物理弹簧算法实现歌词动画效果。如果启用，则会通过弹簧算法实时处理歌词位置，但是需要性能足够强劲的电脑方可流畅运行； 如果不启用，则会回退到基于 `transition` 的过渡效果，对低性能的机器比较友好，但是效果会比较单一|
-| hidePassedLines | 布尔值 | false | 设置是否隐藏已经播放过的歌词行 |
-| lyricLines | LyricLine[] |null| 设置当前播放歌词，要注意传入后这个数组内的信息不得修改，否则会发生错误 |
-| currentTime | 数字 | null | 设置当前播放进度，单位为毫秒且**必须是整数**，此时将会更新内部的歌词进度信息。内部会根据调用间隔和播放进度自动决定如何滚动和显示歌词，所以这个的调用频率越快越准确越好 |
-| linePosXSpringParams| Partial[spring.SpringParams] | null | 设置所有歌词行在​纵坐标上的弹簧属性，包括重量、弹力和阻力。params 需要设置的弹簧属性，提供的属性将会覆盖原来的属性，未提供的属性将会保持原样 |
-| linePosYSpringParams | Partial[spring.SpringParams] | null | 设置所有歌词行在​纵坐标上的弹簧属性，包括重量、弹力和阻力。params 需要设置的弹簧属性，提供的属性将会覆盖原来的属性，未提供的属性将会保持原样 |
-| lineScaleSpringParams | Partial[spring.SpringParams] | null | 设置所有歌词行在​缩放大小上的弹簧属性，包括重量、弹力和阻力。 params 需要设置的弹簧属性，提供的属性将会覆盖原来的属性，未提供的属性将会保持原样 |
-| bottomLine | ReactNode | null | 在一个特殊的底栏元素内加入指定元素，默认是空白的，可以往内部添加任意元素。这个元素始终在歌词的底部，可以用于显示歌曲创作者等信息 |
-| onLyricLineClick | (line: LyricLineMouseEvent) => void | null | 当某个歌词行被左键点击时触发的事件。line 歌词行的事件对象，可以访问到对应的歌词行信息和歌词行索引|
-| onLyricLineContextMenu | (line: LyricLineMouseEvent) => void | null | 当某个歌词行被右键点击时触发的事件。line 歌词行的事件对象，可以访问到对应的歌词行信息和歌词行索引|
+| `disabled` | `boolean` | `false` | 禁用组件内部逐帧 `update()` 循环；设为 `true` 后需要通过 ref 自行更新 Core 实例 |
+| `playing` | `boolean` | `true` | 当前播放状态，控制间奏点等效果的播放/暂停 |
+| `lyricLines` | `LyricLine[]` | `[]` | 当前歌词数据；传入后不要原地修改数组或其中对象 |
+| `currentTime` | `number` | `0` | 当前播放进度，单位为整数毫秒 |
+| `isSeeking` | `boolean` | `false` | 标记当前进度变化是否来自跳转/拖动，用于让布局立即对齐 |
+| `alignAnchor` | `"top" \| "bottom" \| "center"` | Core 默认 | 目标歌词行按顶部、底部或中心对齐 |
+| `alignPosition` | `number` | Core 默认 | 目标歌词行在组件高度中的对齐位置，取值通常为 `0.0` 到 `1.0` |
+| `enableSpring` | `boolean` | `true` | 是否启用弹簧动画；低性能设备可关闭以回退到过渡动画 |
+| `enableBlur` | `boolean` | `true` | 是否启用非当前歌词行的模糊效果 |
+| `enableScale` | `boolean` | `true` | 是否启用非当前歌词行的缩放效果 |
+| `hidePassedLines` | `boolean` | `false` | 是否隐藏已经播放过的歌词行 |
+| `wordFadeWidth` | `number` | `0.5` | 逐词渐变宽度，单位为主歌词字体大小倍数，不能为 `0` |
+| `maskObsceneWordsMode` | `MaskObsceneWordsMode` | `Disabled` | 不雅用语掩码模式 |
+| `maskObsceneWordChar` | `string` | `"*"` | 不雅用语掩码字符，只取第一个字符 |
+| `optimizeOptions` | `OptimizeLyricOptions` | `{}` | 歌词预处理选项；修改后会在下次设置歌词时生效 |
+| `linePosXSpringParams` | `Partial<spring.SpringParams>` | `undefined` | 横向位移弹簧参数；该 Core 方法已标记为将来移除 |
+| `linePosYSpringParams` | `Partial<spring.SpringParams>` | `undefined` | 纵向位移弹簧参数 |
+| `lineScaleSpringParams` | `Partial<spring.SpringParams>` | `undefined` | 缩放弹簧参数 |
+| `bottomLine` | `ReactNode` | `undefined` | 渲染到底部固定区域的自定义内容 |
+| `lyricPlayer` | `new () => LyricPlayerBase` | 默认 DOM 播放器 | 替换底层 Core 播放器实现 |
+| `onLyricLineClick` | `(event: LyricLineMouseEvent) => void` | `undefined` | 左键点击歌词行时触发 |
+| `onLyricLineContextMenu` | `(event: LyricLineMouseEvent) => void` | `undefined` | 右键点击歌词行时触发 |
+
+除上表外，组件也接受普通 `div` 属性，例如 `className`、`style` 和 `data-*`。
+
+## Ref
+
+```tsx
+import { useRef } from "react";
+import { LyricPlayer, type LyricPlayerRef } from "@applemusic-like-lyrics/react";
+
+const playerRef = useRef<LyricPlayerRef>(null);
+
+<LyricPlayer ref={playerRef} />;
+```
+
+`LyricPlayerRef` 包含：
+
+| 字段 | 类型 | 作用 |
+| --- | --- | --- |
+| `lyricPlayer` | `LyricPlayerBase \| undefined` | 底层 Core 播放器实例 |
+| `wrapperEl` | `HTMLDivElement \| null` | React 包装层 DOM |
+
+只有在需要调用 Core 的底层方法、读取底栏元素或在 `disabled` 模式下手动更新动画时，才需要使用 ref。

--- a/packages/docs/src/content/docs/guides/react/quick-start.mdx
+++ b/packages/docs/src/content/docs/guides/react/quick-start.mdx
@@ -2,193 +2,163 @@
 title: 快速入门
 ---
 
-## 概述
+import { Tabs, TabItem } from "@astrojs/starlight/components";
 
-在本文档中，你将学习如何在一个React项目中使用AMLL核心组件。
+本文演示如何在 React 中接入 AMLL 的歌词组件和背景组件。React 绑定只负责把 Core 实例包装成 React 组件；歌词数据仍使用 Core 的 `LyricLine[]`，TTML 推荐通过 `@applemusic-like-lyrics/ttml` 解析。
 
-快速入门文档仅包含使用AMLL的核心功能的教程。部分其他功能需要依赖bncm包。
+## 安装
 
-> 目前，AMLL仅提供了对core的React绑定，AMLL的其他组件并未包含在内，你可以在bncm中找到它们。未来，AMLL将提供包含AMLL播放页面其他组件的react-full。
+<Tabs syncKey="pkg">
+<TabItem label="npm">
 
-## 准备工作
-
-### 1.创建一个React项目
-
-React项目可以使用多种方式创建。本文档将使用与[MDN React教程](https://developer.mozilla.org/zh-CN/docs/Learn/Tools_and_testing/Client-side_JavaScript_frameworks/React_getting_started)相同的create-react-app + jsx来作为示例。
-你可以参考[MDN React教程](https://developer.mozilla.org/zh-CN/docs/Learn/Tools_and_testing/Client-side_JavaScript_frameworks/React_getting_started)创建一个React项目。并使用例如Visual Studio Code等开发软件打开你的项目。
-
-### 2.使用包管理软件安装AMLL
-
-安装AMLL使用的需要的依赖（如果以下列出的依赖包没有安装的话需要自行安装）：
-
-```bash
-npm install @pixi/app @pixi/core @pixi/display @pixi/filter-blur @pixi/filter-bulge-pinch @pixi/filter-color-matrix @pixi/sprite jss jss-preset-default # 使用 npm
-yarn add @pixi/app @pixi/core @pixi/display @pixi/filter-blur @pixi/filter-bulge-pinch @pixi/filter-color-matrix @pixi/sprite jss jss-preset-default # 使用 yarn
+```sh
+npm install @applemusic-like-lyrics/react @applemusic-like-lyrics/ttml react react-dom
+npm install @pixi/app @pixi/core @pixi/display @pixi/filter-blur @pixi/filter-bulge-pinch @pixi/filter-color-matrix @pixi/sprite
 ```
 
-安装 React 绑定需要使用的依赖（如果以下列出的依赖包没有安装的话需要自行安装）：
+</TabItem>
 
-```bash
-npm install react react-dom # 使用 npm
-yarn add react react-dom # 使用 yarn
+<TabItem label="pnpm">
+
+```sh
+pnpm add @applemusic-like-lyrics/react @applemusic-like-lyrics/ttml react react-dom
+pnpm add @pixi/app @pixi/core @pixi/display @pixi/filter-blur @pixi/filter-bulge-pinch @pixi/filter-color-matrix @pixi/sprite
 ```
 
-安装本体框架：
+</TabItem>
 
-```bash
-npm install @applemusic-like-lyrics/react # 使用 npm
-yarn add @applemusic-like-lyrics/react # 使用 yarn
+<TabItem label="Yarn">
+
+```sh
+yarn add @applemusic-like-lyrics/react @applemusic-like-lyrics/ttml react react-dom
+yarn add @pixi/app @pixi/core @pixi/display @pixi/filter-blur @pixi/filter-bulge-pinch @pixi/filter-color-matrix @pixi/sprite
 ```
 
-现在，你已经具备在React中使用AMLL的必要条件
+</TabItem>
+</Tabs>
 
-## 开始使用
+还需要在入口文件或组件文件中引入 Core 样式：
 
-### 1.在React项目中使用AMLL Lyric Player
+```ts
+import "@applemusic-like-lyrics/core/style.css";
+```
 
-Lyric Player是AMLL的核心组件之一，提供歌词的显示功能。
+## 歌词组件
 
-通过`import { LyricPlayer } from "@applemusic-like-lyrics/react";`你可以将AMLL的Lyric Player导入到你的React项目中。
+`LyricPlayer` 通过 props 接收歌词、当前进度和播放状态。TTML 到播放器的数据流是：
 
-随后AMLL Lyric Player的React组件`<LyricPlayer />`便可以使用。
+```ts
+const lyricLines = parseTTML(ttmlText).lines;
+```
 
-下面是一段示例。
+完整示例：
 
-```jsx
-import React from "react";
+```tsx
+import { useEffect, useRef, useState } from "react";
+import type { LyricLine } from "@applemusic-like-lyrics/core";
 import { LyricPlayer } from "@applemusic-like-lyrics/react";
+import { parseTTML } from "@applemusic-like-lyrics/ttml";
+import "@applemusic-like-lyrics/core/style.css";
 
-function App() {
-  return (
-	< LyricPlayer />
-  );
-}
-export default App;
-```
+export default function App() {
+    const audioRef = useRef<HTMLAudioElement>(null);
+    const [lyricLines, setLyricLines] = useState<LyricLine[]>([]);
+    const [currentTime, setCurrentTime] = useState(0);
+    const [playing, setPlaying] = useState(false);
 
-但是现在，AMLL Lyric Player还不会显示任何信息。你需要按照你的需要使用React的Props来为`<LyricPlayer />`赋值，同时根据歌曲的播放逐帧调用AMLL Lyric Player才能显示歌词。
+    useEffect(() => {
+        let canceled = false;
 
-现在，我们对代码稍做修改，使其满足我们的要求。
+        async function loadLyric() {
+            const ttmlText = await fetch("/lyrics.ttml").then((res) => res.text());
+            if (!canceled) setLyricLines(parseTTML(ttmlText).lines);
+        }
 
-```jsx
-import React,{ useState } from "react";
-import { LyricPlayer } from "@applemusic-like-lyrics/react";
-import { parseTTML } from '@applemusic-like-lyrics/core';
+        loadLyric();
+        return () => {
+            canceled = true;
+        };
+    }, []);
 
-const [currentTime, setCurrentTime] = useState(0);
-const [lyricLines, setLyricLines] = useState(0);
-const audio = document.getElementById("amll-audio");//获取<audio>元素
+    useEffect(() => {
+        if (!playing) return;
 
-const parsedResult = parseTTML(TTML-Lyrics-Text);//对歌词进行处理
-setLyricLines(parsedResult);//利用useState设置歌词
+        let frameId = 0;
+        const updateProgress = () => {
+            const audio = audioRef.current;
+            if (audio && !audio.paused) {
+                setCurrentTime(Math.floor(audio.currentTime * 1000));
+                frameId = requestAnimationFrame(updateProgress);
+            }
+        };
 
-let lastTime = -1;
-const frame = (time) => {
-    if (lastTime === -1) {
-        lastTime = time;
+        frameId = requestAnimationFrame(updateProgress);
+        return () => cancelAnimationFrame(frameId);
+    }, [playing]);
+
+    function syncAfterSeek() {
+        const audio = audioRef.current;
+        if (audio) setCurrentTime(Math.floor(audio.currentTime * 1000));
     }
-    if (!audio.paused) {
-        const time = (audio.currentTime * 1000) | 0;
-        setCurrentTime(time);
-    }
-    lastTime = time;
-    requestAnimationFrame(frame);//逐帧调用
-};
-requestAnimationFrame(frame);
 
-function App() {
     return (
-	<>
-	<audio id="amll-audio" src="Audio-Music-Src" controls />
-        <LyricPlayer 
-		lyricLines={lyricLines}  //设置歌词
-		currentTime={currentTime}//通过逐帧调用函数，设置播放时间
-	/>
-	</>
+        <main style={{ height: "100vh" }}>
+            <audio
+                ref={audioRef}
+                src="/song.mp3"
+                controls
+                onPlay={() => setPlaying(true)}
+                onPause={() => setPlaying(false)}
+                onSeeked={syncAfterSeek}
+            />
+            <LyricPlayer
+                lyricLines={lyricLines}
+                currentTime={currentTime}
+                playing={playing}
+                style={{ height: "calc(100vh - 48px)" }}
+            />
+        </main>
     );
 }
-export default App;
 ```
 
-现在，我们创建了一个`<audio>`元素，id为amll-audio，用以播放歌曲。使用React中的useState来设置AMLL Lyric Player的当前播放时间。 
+应用侧负责把音频播放进度转换为整数毫秒并传给 `currentTime`。React 绑定内部已经逐帧调用 Core 的 `update()`，不要在常规用法里再手动调用一次。
 
-定义一个frame函数，通过`requestAnimationFrame();`来逐帧调用。利用`setCurrentTime();`跟随音乐的播放来设置AMLL Lyric Player的时间，从而使AMLL Lyric Player进行歌词的演出。 
+## 背景组件
 
-我们还差最后一步：lyricLines的设置。lyricLines需要处理好的TTML歌词。AMLL提供了TTML歌词的处理程序，即`parseTTML`。我们需要通过`import { parseTTML } from '@applemusic-like-lyrics/core';`来导入。利用`parseTTML();`处理歌词，并将处理好的歌词通过setLyricLines赋值给AMLL Lyric Player。
+`BackgroundRender` 使用 `album` 传入封面图片、视频 URL、`HTMLImageElement` 或 `HTMLVideoElement`。默认渲染器是 `MeshGradientRenderer`；如需旧版 Pixi 背景，可以显式传入 `PixiRenderer`。
 
-> 注意：目前main分支的AMLL无法使用此方法导入parseTTML，你需要从dev分支下packages/core/src/lyric/ttml.ts导入。
+```tsx
+import type { LyricLine } from "@applemusic-like-lyrics/core";
+import { BackgroundRender, LyricPlayer } from "@applemusic-like-lyrics/react";
 
-> 标准的使用方法应为从@applemusic-like-lyrics/ttml导入而不是/core。
-
-### 2.在React项目中使用BackgroundRender
-
-BackgroundRender是AMLL的另一个核心组件。提供了歌曲播放背景显示的功能。
-
-> 在本教程中，为了简洁易懂，将以BackgroundRender中的EplorRenderer（真流体背景）作为示例。
-
-> 在最新的dev分支中，EplorRenderer也为默认的BackgroundRender
-
-我们需要通过
-```jsx
-import { BackgroundRender } from "@applemusic-like-lyrics/react";
-import { EplorRenderer } from '@applemusic-like-lyrics/core';
-```
-来导入BackgroundRender与EplorRenderer。
-
-我们将第三部分中的代码作为示例进行修改。
-
-```jsx
-import React,{ useState } from "react";
-import { LyricPlayer, BackgroundRender } from "@applemusic-like-lyrics/react";
-import { EplorRenderer } from '@applemusic-like-lyrics/core';
-import { parseTTML } from '@applemusic-like-lyrics/core';
-
-const [currentTime, setCurrentTime] = useState(0);
-const [lyricLines, setLyricLines] = useState(0);
-const [albumUrl, setAlbumUrl] = useState(0);
-const audio = document.getElementById("amll-audio");
-
-const parsedResult = parseTTML(TTML-Lyrics-Text);
-setLyricLines(parsedResult);
-
-setAlbumUrl(Album-Pic-Url);//利用useState传入专辑图url
-
-let lastTime = -1;
-const frame = (time) => {
-    if (lastTime === -1) {
-        lastTime = time;
-    }
-    if (!audio.paused) {
-        const time = (audio.currentTime * 1000) | 0;
-        setCurrentTime(time);
-    }
-    lastTime = time;
-    requestAnimationFrame(frame);
-};
-requestAnimationFrame(frame);
-
-function App() {
+export function PlayerView({
+    albumUrl,
+    lyricLines,
+    currentTime,
+    playing,
+}: {
+    albumUrl: string;
+    lyricLines: LyricLine[];
+    currentTime: number;
+    playing: boolean;
+}) {
     return (
-	<>
-    <audio id="amll-audio" src="Audio-Music-Src" controls />
-    <BackgroundRender
-        albumImageUrl={albumUrl} //将歌曲封面图url传入，来生成动态背景
-        renderer={EplorRenderer} //渲染器的选择，这里为EplorRenderer真流体
-    />
-    <LyricPlayer 
-        lyricLines={lyricLines} 
-        currentTime={currentTime} 
-    />
-	</>
+        <div style={{ position: "relative", height: "100vh", overflow: "hidden" }}>
+            <BackgroundRender
+                album={albumUrl}
+                playing={playing}
+                style={{ position: "absolute", inset: 0 }}
+            />
+            <LyricPlayer
+                lyricLines={lyricLines}
+                currentTime={currentTime}
+                playing={playing}
+                style={{ position: "absolute", inset: 0 }}
+            />
+        </div>
     );
 }
-export default App;
 ```
 
-通过使用`<BackgroundRender />`组件，并使用其Props进行设置，我们可以得到动态背景。
-
-将专辑图的url传入`albumImageUrl`，并选择`EplorRenderer`为`renderer`，渲染器会自动处理图片，生成精美的动态背景。
-
-## 结语
-
-我们在本章中学习了如何快速入门AMLL。希望能帮助你更轻松地进行AMLL相关的开发。
+更多配置见 [LyricPlayer 组件](./lyric-player)、[BackgroundRender 组件](./bg-render) 和 [React API 参考](/reference/react)。

--- a/packages/lyric/README-CN.md
+++ b/packages/lyric/README-CN.md
@@ -1,71 +1,48 @@
-# Lyric parser/writer for AMLL
+# AMLL Lyric
 
 [English](./README.md) / 简体中文
-
-此为基于 TypeScript 的重构版本 Lyrics 包，文档未完成。
-
-以下是原文档：
-
----
-
-> 警告：此为个人项目，且尚未完成开发，可能仍有大量问题，所以请勿直接用于生产环境！
 
 ![AMLL-Lyric](https://img.shields.io/badge/Lyric-%23FB8C84?label=Apple%20Music-like%20Lyrics&labelColor=%23FB5C74)
 [![npm](https://img.shields.io/npm/dt/%40applemusic-like-lyrics/lyric)](https://www.npmjs.com/package/@applemusic-like-lyrics/lyric)
 [![npm](https://img.shields.io/npm/v/%40applemusic-like-lyrics%2Flyric)](https://www.npmjs.com/package/@applemusic-like-lyrics/lyric)
 
-一个 AMLL 的歌词解析/生成模块，使用 Rust 编写，并通过 `wasm-pack`
-构建成 WASM 模块以提供给其他项目使用。
+`@applemusic-like-lyrics/lyric` 是 AMLL 的多格式歌词解析/生成包，当前为 TypeScript 实现，支持 LRC、YRC、QRC、Lyricify、TTML 等格式。
 
-本模块由于只着重于歌词内容，所以会丢弃一切和歌词无关的信息，如需获取一个歌词文件中的详细信息（例如歌手）请考虑使用其他框架。
+## 安装
 
-歌词格式支持表：
-
-| 源格式＼目标格式                      | 解析自身格式 | LyRiC 格式 `.lrc` | ESLyric 逐词歌词格式 `.lrc` | 网易云音乐逐词歌词格式 `.yrc` | QQ 音乐逐词歌词格式 `.qrc` | Lyricify Syllable 逐词歌词格式 `.lys` | TTML 歌词格式 `.ttml` | ASS 字幕格式 `.ass` |
-| ------------------------------------- | ------------ | ----------------- | --------------------------- | ----------------------------- | -------------------------- | ------------------------------------- | --------------------- | ------------------- |
-| LyRiC 格式 `.lrc`                     | ✅           | ／                | ✅                          | ✅                            | ✅                         | ✅                                    | ✅                    | ✅                  |
-| ESLyric 逐词歌词格式 `.lrc`           | ✅           | ✅                | ／                          | ✅                            | ✅                         | ✅                                    | ✅                    | ✅                  |
-| 网易云音乐逐词歌词格式 `.yrc`         | ✅           | ✅ [^1]           | ✅ [^1]                     | ／                            | ✅                         | ✅                                    | ✅                    | ✅                  |
-| QQ 音乐逐词歌词格式 `.qrc`            | ✅           | ✅ [^1]           | ✅ [^1]                     | ✅                            | ／                         | ✅                                    | ✅                    | ✅                  |
-| Lyricify Syllable 逐词歌词格式 `.lys` | ✅           | ✅ [^1]           | ✅ [^1]                     | ✅ [^2]                       | ✅ [^2]                    | ／                                    | ✅                    | ✅                  |
-| TTML 歌词格式 `.ttml`                 | ✅           | ✅ [^1]           | ✅ [^1]                     | ✅ [^2]                       | ✅ [^2]                    | ✅ [^3]                               | ／                    | ✅                  |
-| ASS 字幕格式 `.ass`                   | ❌           | ❌                | ❌                          | ❌                            | ❌                         | ❌                                    | ❌                    | ／                  |
-
-[^1]: 会丢失逐词时间数据、演唱属性（背景人声，对唱人声）和 AMLL 元数据
-
-[^2]: 会丢失演唱属性（背景人声，对唱人声）和 AMLL 元数据
-
-[^3]: 会丢失 AMLL 元数据
-
-## 与 Core 歌词组件一起使用
-
-在和二者合用的时候，需要注意**两者的歌词行结构并不完全相同**，需要进行诸如（以 LyRiC 举例）下面的方式进行转换方可被歌词组件正确解析：
-
-```typescript
-import { parseLrc } from "@applemusic-like-lyrics/lyric";
-const lines = parseLrc("[00:00.00]test");
-const converted = lines.map((line, i, lines) => ({
-    words: [
-        {
-            word: line.words[0]?.word ?? "",
-            startTime: line.words[0]?.startTime ?? 0,
-            endTime: lines[i + 1]?.words?.[0]?.startTime ?? Infinity,
-        },
-    ],
-    startTime: line.words[0]?.startTime ?? 0,
-    endTime: lines[i + 1]?.words?.[0]?.startTime ?? Infinity,
-    translatedLyric: "",
-    romanLyric: "",
-    isBG: false,
-    isDuet: false,
-}));
-// 此时就可以将 converted 传给 LyricPlayer 了
+```bash
+npm install @applemusic-like-lyrics/lyric
 ```
 
-推荐使用 TypeScript，这样可以更方便地查错。
+如果使用 pnpm 或 Yarn，将 `npm install` 替换为 `pnpm add` 或 `yarn add`。
 
-## 构建
+## 使用
 
-```shell
-wasm-pack build --target bundler --release --scope applemusic-like-lyrics
+```ts
+import { parseLrc, parseYrc, parseQrc, parseTTML } from "@applemusic-like-lyrics/lyric";
+
+const lrcLines = parseLrc("[00:00.00]Hello AMLL");
+const yrcLines = parseYrc(yrcText);
+const qrcLines = parseQrc(qrcText);
+const ttmlLyric = parseTTML(ttmlText);
 ```
+
+除 TTML 外，解析函数通常返回 `LyricLine[]`；TTML 会返回包含 `lines` 与 `metadata` 的 `TTMLLyric` 对象。
+
+## 与播放器配合
+
+AMLL 播放器需要 Core 的 `LyricLine[]`。使用 TTML 时推荐直接取 `lines`：
+
+```ts
+import type { LyricLine } from "@applemusic-like-lyrics/core";
+import { parseTTML } from "@applemusic-like-lyrics/lyric";
+
+const lyricLines: LyricLine[] = parseTTML(ttmlText).lines;
+```
+
+如果只处理 TTML，优先使用专用包 `@applemusic-like-lyrics/ttml`，它能提供更完整的 TTML API，并支持在 Node 环境中注入 DOM 实现。
+
+## 文档
+
+- 歌词格式指南：https://amll.dev/guides/lyric/quickstart
+- API 参考：https://amll.dev/reference/lyric

--- a/packages/lyric/README.md
+++ b/packages/lyric/README.md
@@ -1,70 +1,48 @@
-# Lyric parser/writer for AMLL
+# AMLL Lyric
 
 English / [简体中文](./README-CN.md)
-
-This is a refactored version of the original lyrics pack. Docs not finished yet.
-
-Below is the original docs.
-
----
-
-> Warning: This is a personal project and is still under development. There may still be many issues, so please do not use it directly in production environments!
 
 ![AMLL-Lyric](https://img.shields.io/badge/Lyric-%23FB8C84?label=Apple%20Music-like%20Lyrics&labelColor=%23FB5C74)
 [![npm](https://img.shields.io/npm/dt/%40applemusic-like-lyrics/lyric)](https://www.npmjs.com/package/@applemusic-like-lyrics/lyric)
 [![npm](https://img.shields.io/npm/v/%40applemusic-like-lyrics%2Flyric)](https://www.npmjs.com/package/@applemusic-like-lyrics/lyric)
 
-A lyric parsing/generation module for AMLL, written in Rust and built into a WASM module using `wasm-pack` for use in other projects.
+`@applemusic-like-lyrics/lyric` is AMLL's multi-format lyric parser/generator package. It is implemented in TypeScript and supports LRC, YRC, QRC, Lyricify, TTML, and more.
 
-Since this module focuses only on lyric content, it discards all information unrelated to lyrics. If you need to get detailed information from a lyric file (such as artist), please consider using other frameworks.
+## Installation
 
-Lyric format support table:
-
-| Source Format＼Target Format                   | Parse Own Format | LyRiC Format `.lrc` | ESLyric Word-by-word Format `.lrc` | NetEase Cloud Music Word-by-word Format `.yrc` | QQ Music Word-by-word Format `.qrc` | Lyricify Syllable Word-by-word Format `.lys` | TTML Lyric Format `.ttml` | ASS Subtitle Format `.ass` |
-| ---------------------------------------------- | ---------------- | ------------------- | ---------------------------------- | ---------------------------------------------- | ----------------------------------- | -------------------------------------------- | ------------------------- | -------------------------- |
-| LyRiC Format `.lrc`                            | ✅               | ／                  | ✅                                 | ✅                                             | ✅                                  | ✅                                           | ✅                        | ✅                         |
-| ESLyric Word-by-word Format `.lrc`             | ✅               | ✅                  | ／                                 | ✅                                             | ✅                                  | ✅                                           | ✅                        | ✅                         |
-| NetEase Cloud Music Word-by-word Format `.yrc` | ✅               | ✅ [^1]             | ✅ [^1]                            | ／                                             | ✅                                  | ✅                                           | ✅                        | ✅                         |
-| QQ Music Word-by-word Format `.qrc`            | ✅               | ✅ [^1]             | ✅ [^1]                            | ✅                                             | ／                                  | ✅                                           | ✅                        | ✅                         |
-| Lyricify Syllable Word-by-word Format `.lys`   | ✅               | ✅ [^1]             | ✅ [^1]                            | ✅ [^2]                                        | ✅ [^2]                             | ／                                           | ✅                        | ✅                         |
-| TTML Lyric Format `.ttml`                      | ✅               | ✅ [^1]             | ✅ [^1]                            | ✅ [^2]                                        | ✅ [^2]                             | ✅ [^3]                                      | ／                        | ✅                         |
-| ASS Subtitle Format `.ass`                     | ❌               | ❌                  | ❌                                 | ❌                                             | ❌                                  | ❌                                           | ❌                        | ／                         |
-
-[^1]: Will lose word-by-word timing data, vocal attributes (background vocals, duet vocals) and AMLL metadata
-
-[^2]: Will lose vocal attributes (background vocals, duet vocals) and AMLL metadata
-
-[^3]: Will lose AMLL metadata
-
-## Using with Core Lyric Component
-
-When using them together, note that **the lyric line structures of the two are not exactly the same**. You need to convert them in a way like the following example (using LyRiC as an example) for the lyric component to parse correctly:
-
-```typescript
-import { parseLrc } from "@applemusic-like-lyrics/lyric";
-const lines = parseLrc("[00:00.00]test");
-const converted = lines.map((line, i, lines) => ({
-    words: [
-        {
-            word: line.words[0]?.word ?? "",
-            startTime: line.words[0]?.startTime ?? 0,
-            endTime: lines[i + 1]?.words?.[0]?.startTime ?? Infinity,
-        },
-    ],
-    startTime: line.words[0]?.startTime ?? 0,
-    endTime: lines[i + 1]?.words?.[0]?.startTime ?? Infinity,
-    translatedLyric: "",
-    romanLyric: "",
-    isBG: false,
-    isDuet: false,
-}));
-// Now you can pass converted to LyricPlayer
+```bash
+npm install @applemusic-like-lyrics/lyric
 ```
 
-Using TypeScript is recommended as it makes it easier to detect errors.
+For pnpm or Yarn, replace `npm install` with `pnpm add` or `yarn add`.
 
-## Building
+## Usage
 
-```shell
-wasm-pack build --target bundler --release --scope applemusic-like-lyrics
+```ts
+import { parseLrc, parseYrc, parseQrc, parseTTML } from "@applemusic-like-lyrics/lyric";
+
+const lrcLines = parseLrc("[00:00.00]Hello AMLL");
+const yrcLines = parseYrc(yrcText);
+const qrcLines = parseQrc(qrcText);
+const ttmlLyric = parseTTML(ttmlText);
 ```
+
+Except for TTML, parse functions usually return `LyricLine[]`. TTML returns a `TTMLLyric` object containing `lines` and `metadata`.
+
+## Use with the Player
+
+The AMLL player consumes Core `LyricLine[]`. For TTML, use the parsed `lines`:
+
+```ts
+import type { LyricLine } from "@applemusic-like-lyrics/core";
+import { parseTTML } from "@applemusic-like-lyrics/lyric";
+
+const lyricLines: LyricLine[] = parseTTML(ttmlText).lines;
+```
+
+If you only work with TTML, prefer the dedicated `@applemusic-like-lyrics/ttml` package. It exposes a fuller TTML API and supports injecting DOM implementations for Node.js usage.
+
+## Documentation
+
+- Lyric format guide: https://amll.dev/en/guides/lyric/quickstart
+- API reference: https://amll.dev/en/reference/lyric

--- a/packages/react-full/README-CN.md
+++ b/packages/react-full/README-CN.md
@@ -2,4 +2,16 @@
 
 > 警告：此为个人项目，且尚未完成开发，可能仍有大量问题，所以请勿直接用于生产环境！
 
-AMLL 组件库的 React 更加模块化的组件绑定，你可以通过此库来更加方便地使用 AMLL 歌词组件和其他主题化模块化组件，并快速搭建出所需要的布局框架，并且提供了相应的槽位以添加自定义内容。
+`@applemusic-like-lyrics/react-full` 提供基于 AMLL Core 和 React 绑定构建的完整播放器组件。需要更完整的播放器布局时使用本包；如果只需要歌词和背景的底层渲染，请使用 `@applemusic-like-lyrics/react`。
+
+## 安装
+
+```bash
+npm install @applemusic-like-lyrics/react-full jotai react react-dom
+```
+
+使用预置组件时引入样式：
+
+```ts
+import "@applemusic-like-lyrics/react-full/style.css";
+```

--- a/packages/react-full/README.md
+++ b/packages/react-full/README.md
@@ -1,7 +1,21 @@
 # AMLL for React (Full ver.)
 
-English / [简体中文](./packages/react-full/README-CN.md)
+English / [简体中文](./README-CN.md)
 
 > Warning: This is a personal project and has not yet been completed. There may still be a lot of problems, so please do not use it directly in the production environment!
 
-AMLL component library's React is a more modular component binding. You can use this library to more conveniently use AMLL lyrics components and other themed modular components, and quickly build the required layout framework, and provide corresponding slots to add custom content.
+`@applemusic-like-lyrics/react-full` provides ready-to-use modular React player components built on top of AMLL Core and React bindings. Use it when you want a fuller player layout instead of wiring only `LyricPlayer` and `BackgroundRender`.
+
+## Installation
+
+```bash
+npm install @applemusic-like-lyrics/react-full jotai react react-dom
+```
+
+Import the package stylesheet when using the prebuilt components:
+
+```ts
+import "@applemusic-like-lyrics/react-full/style.css";
+```
+
+For lower-level lyric rendering, use `@applemusic-like-lyrics/react`.

--- a/packages/react/README-CN.md
+++ b/packages/react/README-CN.md
@@ -8,42 +8,59 @@
 [![npm](https://img.shields.io/npm/dt/%40applemusic-like-lyrics/react)](https://www.npmjs.com/package/@applemusic-like-lyrics/react)
 [![npm](https://img.shields.io/npm/v/%40applemusic-like-lyrics%2Freact)](https://www.npmjs.com/package/@applemusic-like-lyrics/react)
 
-AMLL 组件库的 React 绑定，你可以通过此库来更加方便地使用 AMLL 歌词组件。
-
-详情可以访问 [Core 核心组件的 README.md](../core/README-CN.md)。
+AMLL Core 的 React 绑定，提供 `LyricPlayer` 和 `BackgroundRender` 组件。
 
 ## 安装
 
-安装使用的依赖（如果以下列出的依赖包没有安装的话需要自行安装）：
 ```bash
-npm install @pixi/app @pixi/core @pixi/display @pixi/filter-blur @pixi/filter-bulge-pinch @pixi/filter-color-matrix @pixi/sprite jss jss-preset-default # 使用 npm
-yarn add @pixi/app @pixi/core @pixi/display @pixi/filter-blur @pixi/filter-bulge-pinch @pixi/filter-color-matrix @pixi/sprite jss jss-preset-default # 使用 yarn
+npm install @applemusic-like-lyrics/react @applemusic-like-lyrics/ttml react react-dom
+npm install @pixi/app @pixi/core @pixi/display @pixi/filter-blur @pixi/filter-bulge-pinch @pixi/filter-color-matrix @pixi/sprite
 ```
 
-安装 React 绑定需要使用的依赖（如果以下列出的依赖包没有安装的话需要自行安装）：
-```bash
-npm install react react-dom # 使用 npm
-yarn add react react-dom # 使用 yarn
-```
+如果使用 pnpm 或 Yarn，将 `npm install` 替换为 `pnpm add` 或 `yarn add`。当前包只需要上面列出的 peer 依赖。
 
-安装本体框架：
-```bash
-npm install @applemusic-like-lyrics/react # 使用 npm
-yarn add @applemusic-like-lyrics/react # 使用 yarn
-```
-
-## 使用方式摘要
-
-详细的 API 文档请参考 [./docs/modules.md](./docs/modules.md)
-
-一个测试用途的程序可以在 [../playground/react/src/test.tsx](../playground/react/src/test.tsx) 里找到。
+## 基本使用
 
 ```tsx
+import { useState } from "react";
+import type { LyricLine } from "@applemusic-like-lyrics/core";
 import { LyricPlayer } from "@applemusic-like-lyrics/react";
+import "@applemusic-like-lyrics/core/style.css";
 
-const App = () => {
+export function Lyrics() {
+    const [lyricLines, setLyricLines] = useState<LyricLine[]>([]);
     const [currentTime, setCurrentTime] = useState(0);
-	const [lyricLines, setLyricLines] = useState<LyricLine[]>([]);
-    return <LyricPlayer lyricLines={lyricLines} currentTime={currentTime} />
-};
+    const [playing, setPlaying] = useState(false);
+
+    return (
+        <LyricPlayer
+            lyricLines={lyricLines}
+            currentTime={currentTime}
+            playing={playing}
+            style={{ height: 480 }}
+        />
+    );
+}
 ```
+
+TTML 解析：
+
+```ts
+import { parseTTML } from "@applemusic-like-lyrics/ttml";
+
+const lyricLines = parseTTML(ttmlText).lines;
+```
+
+背景组件：
+
+```tsx
+import { BackgroundRender } from "@applemusic-like-lyrics/react";
+
+<BackgroundRender album="/cover.jpg" playing={playing} />;
+```
+
+## 文档
+
+- 快速入门：https://amll.dev/guides/react/quick-start
+- API 参考：https://amll.dev/reference/react
+- 调试示例：`packages/playground/react`

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -2,48 +2,65 @@
 
 English / [简体中文](./README-CN.md)
 
-> Warning: This is a personal project and is still under development. There may still be many issues, so please do not use it directly in production environments!
+> Warning: This is a personal project and is still under development. There may still be many issues, so please do not use it directly in production environments.
 
 ![AMLL-React](https://img.shields.io/badge/React-%23149eca?label=Apple%20Music-like%20Lyrics&labelColor=%23FB5C74)
 [![npm](https://img.shields.io/npm/dt/%40applemusic-like-lyrics/react)](https://www.npmjs.com/package/@applemusic-like-lyrics/react)
 [![npm](https://img.shields.io/npm/v/%40applemusic-like-lyrics%2Freact)](https://www.npmjs.com/package/@applemusic-like-lyrics/react)
 
-React binding for the AMLL component library, which allows you to use AMLL lyric components more conveniently.
-
-For more details, please visit [Core component README.md](../core/README.md).
+React bindings for AMLL Core, providing `LyricPlayer` and `BackgroundRender` components.
 
 ## Installation
 
-Install the required dependencies (if the dependencies listed below are not installed, you need to install them yourself):
 ```bash
-npm install @pixi/app @pixi/core @pixi/display @pixi/filter-blur @pixi/filter-bulge-pinch @pixi/filter-color-matrix @pixi/sprite jss jss-preset-default # using npm
-yarn add @pixi/app @pixi/core @pixi/display @pixi/filter-blur @pixi/filter-bulge-pinch @pixi/filter-color-matrix @pixi/sprite jss jss-preset-default # using yarn
+npm install @applemusic-like-lyrics/react @applemusic-like-lyrics/ttml react react-dom
+npm install @pixi/app @pixi/core @pixi/display @pixi/filter-blur @pixi/filter-bulge-pinch @pixi/filter-color-matrix @pixi/sprite
 ```
 
-Install the dependencies required for React binding (if the dependencies listed below are not installed, you need to install them yourself):
-```bash
-npm install react react-dom # using npm
-yarn add react react-dom # using yarn
-```
+For pnpm or Yarn, replace `npm install` with `pnpm add` or `yarn add`. The current package only needs the peer dependencies listed above.
 
-Install the framework:
-```bash
-npm install @applemusic-like-lyrics/react # using npm
-yarn add @applemusic-like-lyrics/react # using yarn
-```
-
-## Usage Summary
-
-For detailed API documentation, please refer to [./docs/modules.md](./docs/modules.md)
-
-A test program can be found in [../playground/react/src/test.tsx](../playground/react/src/test.tsx).
+## Basic Usage
 
 ```tsx
+import { useState } from "react";
+import type { LyricLine } from "@applemusic-like-lyrics/core";
 import { LyricPlayer } from "@applemusic-like-lyrics/react";
+import "@applemusic-like-lyrics/core/style.css";
 
-const App = () => {
+export function Lyrics() {
+    const [lyricLines, setLyricLines] = useState<LyricLine[]>([]);
     const [currentTime, setCurrentTime] = useState(0);
-	const [lyricLines, setLyricLines] = useState<LyricLine[]>([]);
-    return <LyricPlayer lyricLines={lyricLines} currentTime={currentTime} />
-};
+    const [playing, setPlaying] = useState(false);
+
+    return (
+        <LyricPlayer
+            lyricLines={lyricLines}
+            currentTime={currentTime}
+            playing={playing}
+            style={{ height: 480 }}
+        />
+    );
+}
 ```
+
+TTML parsing:
+
+```ts
+import { parseTTML } from "@applemusic-like-lyrics/ttml";
+
+const lyricLines = parseTTML(ttmlText).lines;
+```
+
+Background component:
+
+```tsx
+import { BackgroundRender } from "@applemusic-like-lyrics/react";
+
+<BackgroundRender album="/cover.jpg" playing={playing} />;
+```
+
+## Documentation
+
+- Quick start: https://amll.dev/en/guides/react/quick-start
+- API reference: https://amll.dev/en/reference/react
+- Playground: `packages/playground/react`

--- a/packages/ttml/README-CN.md
+++ b/packages/ttml/README-CN.md
@@ -1,7 +1,55 @@
-# Lyric parser/writer for AMLL
+# AMLL TTML
 
 [English](./README.md) / 简体中文
 
-> 警告：此为个人项目，且尚未完成开发，可能仍有大量问题，所以请勿直接用于生产环境！
+![AMLL-TTML](https://img.shields.io/badge/TTML-%23FB8C84?label=Apple%20Music-like%20Lyrics&labelColor=%23FB5C74)
+[![npm](https://img.shields.io/npm/dt/%40applemusic-like-lyrics/ttml)](https://www.npmjs.com/package/@applemusic-like-lyrics/ttml)
+[![npm](https://img.shields.io/npm/v/%40applemusic-like-lyrics%2Fttml)](https://www.npmjs.com/package/@applemusic-like-lyrics/ttml)
 
-一个 AMLL 的 TTML 格式解析/导出模块，使用纯 TypeScript 编写。
+`@applemusic-like-lyrics/ttml` 是 AMLL 的 TTML 解析与生成包，提供 TTML 结构化读写，以及转换为 Core 播放器可直接使用的歌词数据。
+
+## 安装
+
+```bash
+npm install @applemusic-like-lyrics/ttml
+```
+
+## 浏览器快捷用法
+
+```ts
+import { parseTTML, exportTTML } from "@applemusic-like-lyrics/ttml";
+
+const amllLyric = parseTTML(ttmlText);
+const lyricLines = amllLyric.lines;
+const nextTtmlText = exportTTML(amllLyric);
+```
+
+`parseTTML(ttmlText).lines` 可以直接传给 `@applemusic-like-lyrics/core`、`@applemusic-like-lyrics/react` 或 `@applemusic-like-lyrics/vue` 的 `LyricPlayer`。
+
+## Node 环境
+
+快捷函数依赖浏览器全局的 `DOMParser`、`document.implementation` 和 `XMLSerializer`。在 Node 环境中，请使用类模式并注入 DOM 实现，例如 `@xmldom/xmldom`：
+
+```ts
+import { DOMImplementation, DOMParser, XMLSerializer } from "@xmldom/xmldom";
+import { TTMLGenerator, TTMLParser, toAmllLyrics } from "@applemusic-like-lyrics/ttml";
+
+const parser = new TTMLParser({
+    domParser: new DOMParser(),
+});
+
+const parsed = parser.parse(ttmlText);
+const amllLyric = toAmllLyrics(parsed);
+
+const generator = new TTMLGenerator({
+    domImplementation: new DOMImplementation(),
+    xmlSerializer: new XMLSerializer(),
+});
+
+const nextTtmlText = generator.generate(parsed);
+```
+
+## 文档
+
+- TTML 指南：https://amll.dev/guides/lyric/ttml
+- API 参考：https://amll.dev/reference/ttml

--- a/packages/ttml/README.md
+++ b/packages/ttml/README.md
@@ -1,7 +1,55 @@
-# Lyric parser/writer for AMLL
+# AMLL TTML
 
 English / [简体中文](./README-CN.md)
 
-> Warning: This is a personal project and is still under development. There may still be many issues, so please do not use it directly in production environments!
+![AMLL-TTML](https://img.shields.io/badge/TTML-%23FB8C84?label=Apple%20Music-like%20Lyrics&labelColor=%23FB5C74)
+[![npm](https://img.shields.io/npm/dt/%40applemusic-like-lyrics/ttml)](https://www.npmjs.com/package/@applemusic-like-lyrics/ttml)
+[![npm](https://img.shields.io/npm/v/%40applemusic-like-lyrics%2Fttml)](https://www.npmjs.com/package/@applemusic-like-lyrics/ttml)
 
-A TTML format parser/exporter module for AMLL, written in pure TypeScript.
+`@applemusic-like-lyrics/ttml` is AMLL's TTML parser/generator package. It can read/write structured TTML and convert TTML lyrics into data that Core players can consume directly.
+
+## Installation
+
+```bash
+npm install @applemusic-like-lyrics/ttml
+```
+
+## Browser Shortcut
+
+```ts
+import { parseTTML, exportTTML } from "@applemusic-like-lyrics/ttml";
+
+const amllLyric = parseTTML(ttmlText);
+const lyricLines = amllLyric.lines;
+const nextTtmlText = exportTTML(amllLyric);
+```
+
+`parseTTML(ttmlText).lines` can be passed directly to `LyricPlayer` from `@applemusic-like-lyrics/core`, `@applemusic-like-lyrics/react`, or `@applemusic-like-lyrics/vue`.
+
+## Node.js
+
+The shortcut functions depend on browser globals: `DOMParser`, `document.implementation`, and `XMLSerializer`. In Node.js, use class mode and inject DOM implementations, for example with `@xmldom/xmldom`:
+
+```ts
+import { DOMImplementation, DOMParser, XMLSerializer } from "@xmldom/xmldom";
+import { TTMLGenerator, TTMLParser, toAmllLyrics } from "@applemusic-like-lyrics/ttml";
+
+const parser = new TTMLParser({
+    domParser: new DOMParser(),
+});
+
+const parsed = parser.parse(ttmlText);
+const amllLyric = toAmllLyrics(parsed);
+
+const generator = new TTMLGenerator({
+    domImplementation: new DOMImplementation(),
+    xmlSerializer: new XMLSerializer(),
+});
+
+const nextTtmlText = generator.generate(parsed);
+```
+
+## Documentation
+
+- TTML guide: https://amll.dev/en/guides/lyric/ttml
+- API reference: https://amll.dev/en/reference/ttml

--- a/packages/vue/README-CN.md
+++ b/packages/vue/README-CN.md
@@ -8,45 +8,57 @@
 [![npm](https://img.shields.io/npm/dt/%40applemusic-like-lyrics/vue)](https://www.npmjs.com/package/@applemusic-like-lyrics/vue)
 [![npm](https://img.shields.io/npm/v/%40applemusic-like-lyrics%2Fvue)](https://www.npmjs.com/package/@applemusic-like-lyrics/vue)
 
-AMLL 组件库的 Vue 绑定，你可以通过此库来更加方便地使用 AMLL 歌词组件。
-
-详情可以访问 [Core 核心组件的 README.md](../core/README-CN.md)。
+AMLL Core 的 Vue 绑定，提供 `LyricPlayer` 和 `BackgroundRender` 组件。
 
 ## 安装
 
-安装使用的依赖（如果以下列出的依赖包没有安装的话需要自行安装）：
 ```bash
-npm install @pixi/app @pixi/core @pixi/display @pixi/filter-blur @pixi/filter-bulge-pinch @pixi/filter-color-matrix @pixi/sprite jss jss-preset-default # 使用 npm
-yarn add @pixi/app @pixi/core @pixi/display @pixi/filter-blur @pixi/filter-bulge-pinch @pixi/filter-color-matrix @pixi/sprite jss jss-preset-default # 使用 yarn
+npm install @applemusic-like-lyrics/vue @applemusic-like-lyrics/ttml vue
+npm install @pixi/app @pixi/core @pixi/display @pixi/filter-blur @pixi/filter-bulge-pinch @pixi/filter-color-matrix @pixi/sprite
 ```
 
-安装 Vue 绑定需要使用的依赖（如果以下列出的依赖包没有安装的话需要自行安装）：
-```bash
-npm install vue # 使用 npm
-yarn add vue # 使用 yarn
-```
+如果使用 pnpm 或 Yarn，将 `npm install` 替换为 `pnpm add` 或 `yarn add`。当前包只需要上面列出的 peer 依赖。
 
-安装本体框架：
-```bash
-npm install @applemusic-like-lyrics/vue # 使用 npm
-yarn add @applemusic-like-lyrics/vue # 使用 yarn
-```
-
-## 使用方式摘要
-
-由于 Vue 组件不方便生成 API 文档，所以还请自行查阅类型定义文件确定用法。
-
-（或者参考 React 绑定，二者属性和引用方式完全一致）
-
-一个测试用途的程序可以在 [../playground/vue/src/test.ts](../playground/vue/src/test.ts) 里找到。
+## 基本使用
 
 ```vue
-<tamplate>
-    <LyricPlayer :lyric-lines="[]" :current-time="0" />
-</tamplate>
+<template>
+    <LyricPlayer
+        :lyric-lines="lyricLines"
+        :current-time="currentTime"
+        :playing="playing"
+        style="height: 480px"
+    />
+</template>
 
 <script setup lang="ts">
+import type { LyricLine } from "@applemusic-like-lyrics/core";
 import { LyricPlayer } from "@applemusic-like-lyrics/vue";
+import { shallowRef, ref } from "vue";
+import "@applemusic-like-lyrics/core/style.css";
 
+const lyricLines = shallowRef<LyricLine[]>([]);
+const currentTime = ref(0);
+const playing = ref(false);
 </script>
 ```
+
+TTML 解析：
+
+```ts
+import { parseTTML } from "@applemusic-like-lyrics/ttml";
+
+lyricLines.value = parseTTML(ttmlText).lines;
+```
+
+背景组件：
+
+```vue
+<BackgroundRender :album="albumUrl" :playing="playing" />
+```
+
+## 文档
+
+- 快速入门：https://amll.dev/guides/overview/quickstart#vue-绑定
+- API 参考：https://amll.dev/reference/vue
+- 调试示例：`packages/playground/vue`

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -2,51 +2,63 @@
 
 English / [简体中文](./README-CN.md)
 
-> Warning: This is a personal project and is still under development. There may still be many issues, so please do not use it directly in production environments!
+> Warning: This is a personal project and is still under development. There may still be many issues, so please do not use it directly in production environments.
 
 ![AMLL-Vue](https://img.shields.io/badge/Vue-%2342d392?label=Apple%20Music-like%20Lyrics&labelColor=%23FB5C74)
 [![npm](https://img.shields.io/npm/dt/%40applemusic-like-lyrics/vue)](https://www.npmjs.com/package/@applemusic-like-lyrics/vue)
 [![npm](https://img.shields.io/npm/v/%40applemusic-like-lyrics%2Fvue)](https://www.npmjs.com/package/@applemusic-like-lyrics/vue)
 
-Vue binding for the AMLL component library, which allows you to use AMLL lyric components more conveniently.
-
-For more details, please visit [Core component README.md](../core/README.md).
+Vue bindings for AMLL Core, providing `LyricPlayer` and `BackgroundRender` components.
 
 ## Installation
 
-Install the required dependencies (if the dependencies listed below are not installed, you need to install them yourself):
 ```bash
-npm install @pixi/app @pixi/core @pixi/display @pixi/filter-blur @pixi/filter-bulge-pinch @pixi/filter-color-matrix @pixi/sprite jss jss-preset-default # using npm
-yarn add @pixi/app @pixi/core @pixi/display @pixi/filter-blur @pixi/filter-bulge-pinch @pixi/filter-color-matrix @pixi/sprite jss jss-preset-default # using yarn
+npm install @applemusic-like-lyrics/vue @applemusic-like-lyrics/ttml vue
+npm install @pixi/app @pixi/core @pixi/display @pixi/filter-blur @pixi/filter-bulge-pinch @pixi/filter-color-matrix @pixi/sprite
 ```
 
-Install the dependencies required for Vue binding (if the dependencies listed below are not installed, you need to install them yourself):
-```bash
-npm install vue # using npm
-yarn add vue # using yarn
-```
+For pnpm or Yarn, replace `npm install` with `pnpm add` or `yarn add`. The current package only needs the peer dependencies listed above.
 
-Install the framework:
-```bash
-npm install @applemusic-like-lyrics/vue # using npm
-yarn add @applemusic-like-lyrics/vue # using yarn
-```
-
-## Usage Summary
-
-Since Vue components are not convenient for generating API documentation, please refer to the type definition files to determine usage.
-
-(Or refer to the React binding, as both have identical properties and reference methods)
-
-A test program can be found in [../playground/vue/src/test.ts](../playground/vue/src/test.ts).
+## Basic Usage
 
 ```vue
-<tamplate>
-    <LyricPlayer :lyric-lines="[]" :current-time="0" />
-</tamplate>
+<template>
+    <LyricPlayer
+        :lyric-lines="lyricLines"
+        :current-time="currentTime"
+        :playing="playing"
+        style="height: 480px"
+    />
+</template>
 
 <script setup lang="ts">
+import type { LyricLine } from "@applemusic-like-lyrics/core";
 import { LyricPlayer } from "@applemusic-like-lyrics/vue";
+import { shallowRef, ref } from "vue";
+import "@applemusic-like-lyrics/core/style.css";
 
+const lyricLines = shallowRef<LyricLine[]>([]);
+const currentTime = ref(0);
+const playing = ref(false);
 </script>
 ```
+
+TTML parsing:
+
+```ts
+import { parseTTML } from "@applemusic-like-lyrics/ttml";
+
+lyricLines.value = parseTTML(ttmlText).lines;
+```
+
+Background component:
+
+```vue
+<BackgroundRender :album="albumUrl" :playing="playing" />
+```
+
+## Documentation
+
+- Quick start: https://amll.dev/en/guides/overview/quickstart#vue-bindings
+- API reference: https://amll.dev/en/reference/vue
+- Playground: `packages/playground/vue`


### PR DESCRIPTION
主要改动：

- 重写中英文 overview quickstart、React quick-start、React LyricPlayer/BackgroundRender/introduction 指南。
- 更新根 README 与 core/react/vue/lyric/ttml/react-full README。
- 统一最新调用方式：TTML 使用 @applemusic-like-lyrics/ttml，React/Vue 示例使用正确 hooks/响应式状态，背景组件使用 album - 与默认 MeshGradientRenderer。
- 清理旧依赖说明、失效 API 文档链接和不可运行示例。