### PR TITLE
docs: 调整构建配置以避免输出目录形式

### DIFF
--- a/packages/docs/astro.config.ts
+++ b/packages/docs/astro.config.ts
@@ -96,6 +96,9 @@ const contributeSidebar = [
 export default defineConfig({
 	site: "https://amll.dev",
 	trailingSlash: "never",
+	build: {
+		format: "file",
+	},
 	integrations: [
 		react(),
 		starlight({


### PR DESCRIPTION
解决线上仍然出现 trailing slash 导致现链接落空