### PR TITLE
docs: patch starlight 实现纯净 URL

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -289,6 +289,9 @@
     "@applemusic-like-lyrics/lyric",
     "nx",
   ],
+  "patchedDependencies": {
+    "@astrojs/starlight@0.38.3": "patches/@astrojs%2Fstarlight@0.38.3.patch",
+  },
   "catalog": {
     "@biomejs/biome": "^2.4.8",
     "@rolldown/plugin-babel": "^0.2.3",

--- a/nx.json
+++ b/nx.json
@@ -49,7 +49,8 @@
 				"tsconfig.base.json",
 				"packages/docs/**",
 				"packages/*/docs/**",
-				"packages/playground/**"
+				"packages/playground/**",
+				"patches/**"
 			]
 		},
 		"version": {

--- a/package.json
+++ b/package.json
@@ -51,5 +51,8 @@
 		"esbuild",
 		"nx",
 		"sharp"
-	]
+	],
+	"patchedDependencies": {
+		"@astrojs/starlight@0.38.3": "patches/@astrojs%2Fstarlight@0.38.3.patch"
+	}
 }

--- a/patches/@astrojs%2Fstarlight@0.38.3.patch
+++ b/patches/@astrojs%2Fstarlight@0.38.3.patch
@@ -1,0 +1,25 @@
+diff --git a/utils/createPathFormatter.ts b/utils/createPathFormatter.ts
+index 52c9527c6d8c6756125c2f746cf14d055ed1e3ef..081974cdd61c42b1aed306449e9bb7be4d4ecd19 100644
+--- a/utils/createPathFormatter.ts
++++ b/utils/createPathFormatter.ts
+@@ -37,7 +37,8 @@ function formatPath(
+ 	href: string,
+ 	{ format = 'directory', trailingSlash = 'ignore' }: FormatPathOptions
+ ) {
+-	const formatStrategy = formatStrategies[format];
++	const useCleanFileUrls = format === 'file' && trailingSlash === 'never';
++	const formatStrategy = useCleanFileUrls ? defaultFormatStrategy : formatStrategies[format];
+ 	const trailingSlashStrategy = trailingSlashStrategies[trailingSlash];
+ 
+ 	// Handle extension
+@@ -46,8 +47,8 @@ function formatPath(
+ 	// Add base
+ 	href = formatStrategy.addBase(href);
+ 
+-	// Skip trailing slash handling for `build.format: 'file'`
+-	if (format === 'file') return href;
++	// Skip trailing slash handling for `build.format: 'file'`, except when clean URLs are used.
++	if (format === 'file' && !useCleanFileUrls) return href;
+ 
+ 	// Handle trailing slash
+ 	href = href === '/' ? href : trailingSlashStrategy(href);


### PR DESCRIPTION
移除 Starlight 添加的 `.html` 链接后缀，还我清洁 URL

~~隔壁 VitePress 一行配置就行了，也不知道 Starlight 吃错了什么药非得给每个链接结尾加上 `.html`，首页还要加上 `index.html`，还不能关~~