### PR TITLE
chore: 映射真实源代码

### DIFF
--- a/.nx/version-plans/version-plan-1778659377437.md
+++ b/.nx/version-plans/version-plan-1778659377437.md
@@ -1,0 +1,5 @@
+---
+core-bundle: patch
+---
+
+chore(core): 优化类型定义

--- a/nx.json
+++ b/nx.json
@@ -55,7 +55,9 @@
 				"packages/ws-protocol",
 				"patches/**",
 				"**/test/**",
-				"**/tests/**"
+				"**/tests/**",
+				"**/tsconfig*",
+				"**/tsdown*"
 			]
 		},
 		"version": {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,4 @@
+/// <reference path="./types.d.ts" />
 export * from "./bg-render/index.ts";
 export type * from "./interfaces.ts";
 export * from "./lyric-player/index.ts";

--- a/packages/playground/core/tsconfig.app.json
+++ b/packages/playground/core/tsconfig.app.json
@@ -4,7 +4,9 @@
 	"compilerOptions": {
 		"isolatedDeclarations": false,
 		"paths": {
-			"@/*": ["./src/*"]
+			"@/*": ["./src/*"],
+			"@applemusic-like-lyrics/core": ["../../core/src/index.ts"],
+			"@applemusic-like-lyrics/lyric": ["../../lyric/src/index.ts"]
 		}
 	}
 }

--- a/packages/vue/tsconfig.dts.json
+++ b/packages/vue/tsconfig.dts.json
@@ -1,0 +1,9 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		// 让 tsgo 解析 dist 下的类型声明而非源码，避免在 core/src 下生成 .d.ts 文件
+		"paths": {
+			"@applemusic-like-lyrics/core": ["../core/dist/amll-core.d.mts"]
+		}
+	}
+}

--- a/packages/vue/tsdown.config.ts
+++ b/packages/vue/tsdown.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
 	entry: { "amll-vue": "./src/index.ts" },
 	dts: {
 		tsgo: true,
+		tsconfig: "./tsconfig.dts.json",
 	},
 	plugins: [
 		pluginBabel({

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -31,6 +31,21 @@
 		"noPropertyAccessFromIndexSignature": false,
 		"noUncheckedIndexedAccess": false,
 		"exactOptionalPropertyTypes": false,
-		"noImplicitReturns": true
+		"noImplicitReturns": true,
+
+		// 映射各个子包的路径以便让 IDE 可以跳转到实际的源码而不是 dist 目录
+		"paths": {
+			"@applemusic-like-lyrics/core": ["./packages/core/src/index.ts"],
+			"@applemusic-like-lyrics/core/style.css": [
+				"./packages/core/src/styles/index.css"
+			],
+			"@applemusic-like-lyrics/react": ["./packages/react/src/index.ts"],
+			"@applemusic-like-lyrics/vue": ["./packages/vue/src/index.ts"],
+			"@applemusic-like-lyrics/react-full": [
+				"./packages/react-full/src/index.ts"
+			],
+			"@applemusic-like-lyrics/lyric": ["./packages/lyric/src/index.ts"],
+			"@applemusic-like-lyrics/ttml": ["./packages/ttml/src/index.ts"]
+		}
 	}
 }


### PR DESCRIPTION
## 摘要
在 TS 配置文件中映射各个子包的路径，这样就可以直接跳转到源代码而不是构建产物了

## 改动点
- 在根目录的 base 配置中添加了所有子包的 paths
- 为 playground/core 添加了 core 和 lyric 的 paths

## 验证
<img width="200" height="200" alt="works on my machine" src="https://github.com/user-attachments/assets/30de0668-9415-4d12-8ec8-7a3d36830c07" />
