### PR TITLE
fix: 修复 Vue playground isolatedDeclarations 导致的类型错误

### DIFF
--- a/packages/playground/vue/src/TestApp.vue
+++ b/packages/playground/vue/src/TestApp.vue
@@ -39,13 +39,13 @@
 <script setup lang="ts">
 import type { LyricLine } from "@applemusic-like-lyrics/core";
 import { parseTTML } from "@applemusic-like-lyrics/lyric";
-import { onMounted, reactive, ref, shallowRef } from "vue";
 import {
 	BackgroundRender,
 	type BackgroundRenderRef,
 	LyricPlayer,
 	type LyricPlayerRef,
 } from "@applemusic-like-lyrics/vue";
+import { onMounted, reactive, ref, shallowRef } from "vue";
 
 const audioRef = ref<HTMLAudioElement>();
 const state = reactive({

--- a/packages/playground/vue/tsconfig.json
+++ b/packages/playground/vue/tsconfig.json
@@ -2,6 +2,7 @@
 	"extends": "../../../tsconfig.base.json",
 	"include": ["src"],
 	"compilerOptions": {
+		"isolatedDeclarations": false,
 		"jsxImportSource": "vue",
 		"jsx": "preserve"
 	}


### PR DESCRIPTION
apoint 在添加全局 isolatedDeclarations 的时候把 Vue playground 忘了，导致类型错误