### PR TITLE
refactor(core): 将背景歌词迁移到子行功能，并为歌词行增加唯一键值

### DIFF
--- a/.nx/version-plans/version-plan-1779006852486.md
+++ b/.nx/version-plans/version-plan-1779006852486.md
@@ -1,0 +1,7 @@
+---
+core-bundle: minor
+'@applemusic-like-lyrics/lyric': minor
+'@applemusic-like-lyrics/ttml': minor
+---
+
+refactor(core): 实现子行功能取代背景行，并为歌词行增加唯一键值

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -60,15 +60,15 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "catalog:",
+		"@tsdown/css": "catalog:",
 		"@types/deep-freeze": "^0.1.5",
 		"@types/stats.js": "^0.17.3",
 		"@types/ungap__structured-clone": "^1.2.0",
 		"lil-gui": "^0.21.0",
 		"stats.js": "^0.17.0",
+		"tsdown": "catalog:",
 		"typedoc": "catalog:",
-		"typedoc-plugin-markdown": "catalog:",
-		"@tsdown/css": "catalog:",
-		"tsdown": "catalog:"
+		"typedoc-plugin-markdown": "catalog:"
 	},
 	"peerDependencies": {
 		"@pixi/app": "*",
@@ -83,6 +83,7 @@
 		"@ungap/structured-clone": "catalog:",
 		"bezier-easing": "^3.0.0",
 		"deep-freeze": "^0.0.1",
-		"gl-matrix": "4.0.0-beta.2"
+		"gl-matrix": "4.0.0-beta.2",
+		"uid": "^2.0.2"
 	}
 }

--- a/packages/core/src/interfaces.ts
+++ b/packages/core/src/interfaces.ts
@@ -43,8 +43,13 @@ export interface LyricWord extends LyricWordBase {
 	ruby?: LyricWordBase[];
 }
 
+/** 歌词行的唯一键值，对于子行歌词相关功能来说需要提供以正确查询父歌词行 */
+export type LyricLineKey = string | number;
+
 /** 一行歌词，存储多个单词 */
 export interface LyricLine {
+	/** 这个歌词行的唯一键值，对于子行歌词相关功能来说需要提供以正确查询父歌词行 */
+	key?: LyricLineKey;
 	/**
 	 * 该行的所有单词
 	 * 如果是 LyRiC 等只能表达一行歌词的格式，这里就只会有一个单词且通常其始末时间和本结构的 `startTime` 和 `endTime` 相同
@@ -58,8 +63,12 @@ export interface LyricLine {
 	startTime: number;
 	/** 句子的结束时间，单位为毫秒 */
 	endTime: number;
-	/** 该行是否为背景歌词行，当该行歌词的上一句非背景歌词被激活时，这行歌词将会显示出来，注意每个非背景歌词下方只能拥有一个背景歌词 */
-	isBG: boolean;
+	/**
+	 * 该歌词行的父级歌词行键值
+	 * 在 AMLL 中，如果这个歌词存在一个父级歌词，则这个歌词就会成为子歌词（又称背景歌词）
+	 * 且在排版的时候，会根据开始时间早于或晚于父级歌词来考虑将其排序到主歌词行的前面或者后面
+	 */
+	parentLyricLineKey?: LyricLineKey;
 	/** 该行是否为对唱歌词行（即歌词行靠右对齐） */
 	isDuet: boolean;
 }

--- a/packages/core/src/lyric-player/base/index.ts
+++ b/packages/core/src/lyric-player/base/index.ts
@@ -3,6 +3,7 @@ import type {
 	Disposable,
 	HasElement,
 	LyricLine,
+	LyricLineKey,
 	LyricWord,
 	OptimizeLyricOptions,
 } from "#interfaces";
@@ -18,6 +19,9 @@ import {
 	computeCurrentInterlude,
 	computeLinePosYSpringParams,
 	type PlayerLayoutState,
+	computeScrollOffset,
+	computeShouldOccupyHeight,
+	computeIsLyricLineActive,
 } from "./layout.ts";
 import type { LyricLineBase } from "./line.ts";
 import {
@@ -63,10 +67,14 @@ export abstract class LyricPlayerBase
 	lyricLinesSize: WeakMap<LyricLineBase, [number, number]> = new WeakMap();
 	/** @internal */
 	lyricLineElementMap: WeakMap<Element, LyricLineBase> = new WeakMap();
+	/** @internal */
+	lyricLineKeyMap: Map<LyricLineKey, LyricLine> = new Map();
 	protected currentLyricLines: LyricLine[] = [];
 	// protected currentLyricLineObjects: LyricLineBase[] = [];
 	protected processedLines: LyricLine[] = [];
-	protected lyricLinesIndexes: WeakMap<LyricLineBase, number> = new WeakMap();
+	protected displayLyricLinesIndicies: WeakMap<LyricLineBase, number> =
+		new WeakMap();
+	protected lyricLinesIndicies: WeakMap<LyricLine, number> = new WeakMap();
 	protected isNonDynamic = false;
 	protected hasDuetLine = false;
 	protected disableSpring = false;
@@ -417,7 +425,7 @@ export abstract class LyricPlayerBase
 	}
 
 	/**
-	 * 设置当前播放歌词，要注意传入后这个数组内的信息不得修改，否则会发生错误
+	 * 设置当前播放歌词，传入的歌词数组结构会被结构化克隆，并对其实行有关的歌词后处理操作
 	 * @param lines 歌词数组
 	 * @param initialTime 初始时间，默认为 0
 	 */
@@ -430,8 +438,11 @@ export abstract class LyricPlayerBase
 		this.timelineState.lastCurrentTime = initialTime;
 		this.timelineState.currentTime = initialTime;
 		this.currentLyricLines = structuredClone(lines);
+		// 排序后确保歌词时序正确，同时决定所有歌词的显示顺序
+		this.currentLyricLines.sort((a, b) => a.startTime - b.startTime);
 		this.processedLines = structuredClone(this.currentLyricLines);
 		optimizeLyricLines(this.processedLines, this.optimizeOptions);
+		this.updateLyricLineKeyMap();
 
 		this.isNonDynamic = true;
 		for (const line of this.processedLines) {
@@ -454,6 +465,15 @@ export abstract class LyricPlayerBase
 
 		if (import.meta.env.DEV) {
 			console.log("歌词处理完成", this);
+		}
+	}
+
+	private updateLyricLineKeyMap() {
+		this.lyricLineKeyMap.clear();
+		for (const line of this.processedLines) {
+			const key = line.key;
+			if (key === undefined) continue;
+			this.lyricLineKeyMap.set(key, line);
 		}
 	}
 
@@ -504,12 +524,6 @@ export abstract class LyricPlayerBase
 			stateResult,
 		});
 
-		for (const id of commitResult.linesToDisable)
-			this.currentLyricLineObjects[id]?.disable();
-
-		for (const id of commitResult.linesToEnable)
-			this.currentLyricLineObjects[id]?.enable();
-
 		if (commitResult.shouldResetScroll) this.resetScroll();
 		if (commitResult.shouldLayout) this.calcLayout();
 	}
@@ -531,7 +545,8 @@ export abstract class LyricPlayerBase
 	 * @param sync 是否同步执行，通常用于初始化或 Resize 时立即布局
 	 * @param force 是否绕过弹簧效果强制更新位置
 	 */
-	async calcLayout(sync = false, force = false): Promise<void> {
+	calcLayout(sync = false, force = false): void {
+		performance.mark("amll-calcLayout-start");
 		const interlude = computeCurrentInterlude({
 			currentTime: this.timelineState.currentTime,
 			scrollToIndex: this.timelineState.scrollToIndex,
@@ -578,16 +593,13 @@ export abstract class LyricPlayerBase
 		}
 		// 避免一开始就让所有歌词行挤在一起
 		const LINE_HEIGHT_FALLBACK = this.size[1] / 5;
-		const scrollOffset = this.currentLyricLineObjects
-			.slice(0, targetAlignIndex)
-			.reduce(
-				(acc, el) =>
-					acc +
-					(el.getLine().isBG && this.timelineState.isPlaying
-						? 0
-						: (this.lyricLinesSize.get(el)?.[1] ?? LINE_HEIGHT_FALLBACK)),
-				0,
-			);
+		const scrollOffset = computeScrollOffset({
+			currentLyricLineObjects: this.currentLyricLineObjects,
+			lyricLinesSize: this.lyricLinesSize,
+			fallbackHeight: LINE_HEIGHT_FALLBACK,
+			targetAlignIndex,
+			isPlaying: this.timelineState.isPlaying,
+		});
 		this.scrollState.scrollBoundary.minOffset = -scrollOffset;
 		curPos -= scrollOffset;
 		curPos += this.size[1] * this.layoutState.alignPosition;
@@ -624,8 +636,14 @@ export abstract class LyricPlayerBase
 		let baseDelay = sync ? 0 : 0.05;
 		let setDots = false;
 		this.currentLyricLineObjects.forEach((lineObj, i) => {
-			const hasBuffered = this.timelineState.bufferedLines.has(i);
 			const line = lineObj.getLine();
+			const isActiveLine = computeIsLyricLineActive({
+				line,
+				lineIndex: i,
+				bufferedLines: this.timelineState.bufferedLines,
+				lyricLineKeyMap: this.lyricLineKeyMap,
+				lyricLinesIndicies: this.lyricLinesIndicies,
+			});
 
 			const shouldShowDots = interlude && i === interlude.anchorLineIndex + 1;
 
@@ -656,7 +674,7 @@ export abstract class LyricPlayerBase
 				lineIndex: i,
 				scrollToIndex: this.timelineState.scrollToIndex,
 				latestIndex,
-				hasBuffered,
+				isActiveLine,
 				hidePassedLines: this.hidePassedLines,
 				isPlaying: this.timelineState.isPlaying,
 				isNonDynamic: this.isNonDynamic,
@@ -677,16 +695,27 @@ export abstract class LyricPlayerBase
 				presentation.renderMode,
 			);
 
+			if (presentation.isActive) {
+				lineObj.enable();
+			} else {
+				lineObj.disable();
+			}
+
 			if (
-				line.isBG &&
-				(presentation.isActive || !this.timelineState.isPlaying)
+				computeShouldOccupyHeight({
+					line,
+					lyricLineKeyMap: this.lyricLineKeyMap,
+					lyricLinesIndicies: this.lyricLinesIndicies,
+					bufferedLines: this.timelineState.bufferedLines,
+					isPresentationActive: presentation.isActive,
+					isPlaying: this.timelineState.isPlaying,
+				})
 			) {
 				curPos += this.lyricLinesSize.get(lineObj)?.[1] ?? LINE_HEIGHT_FALLBACK;
-			} else if (!line.isBG) {
-				curPos += this.lyricLinesSize.get(lineObj)?.[1] ?? LINE_HEIGHT_FALLBACK;
 			}
+
 			if (curPos >= 0 && !this.timelineState.isSeeking) {
-				if (!line.isBG) delay += baseDelay;
+				if (!line.parentLyricLineKey) delay += baseDelay;
 
 				if (i >= this.timelineState.scrollToIndex) baseDelay /= 1.05;
 			}
@@ -706,6 +735,13 @@ export abstract class LyricPlayerBase
 		});
 
 		this.bottomLine.setTransform(0, curPos, finalBottomBlur, force, delay);
+
+		performance.mark("amll-calcLayout-end");
+		performance.measure(
+			"amll-calcLayout",
+			"amll-calcLayout-start",
+			"amll-calcLayout-end",
+		);
 	}
 
 	/**
@@ -745,7 +781,7 @@ export abstract class LyricPlayerBase
 			...params,
 		};
 		for (const lineObj of this.currentLyricLineObjects) {
-			if (lineObj.getLine().isBG) {
+			if (lineObj.getLine().parentLyricLineKey) {
 				lineObj.lineTransforms.scale.updateParams(this.scaleForBGSpringParams);
 			} else {
 				lineObj.lineTransforms.scale.updateParams(this.scaleSpringParams);

--- a/packages/core/src/lyric-player/base/layout.ts
+++ b/packages/core/src/lyric-player/base/layout.ts
@@ -1,7 +1,8 @@
-import type { LyricLine } from "#interfaces";
+import type { LyricLine, LyricLineKey } from "#interfaces";
 import { clamp } from "#utils/clamp.ts";
 import type { SpringParams } from "#utils/spring.ts";
 import { type LayoutAlignAnchor, LyricLineRenderMode } from "./consts.ts";
+import type { LyricLineBase } from "./line.ts";
 import type { PlayerTimelineState } from "./timeline.ts";
 
 /**
@@ -186,6 +187,42 @@ export function computeLinePosYSpringParams(
 	};
 }
 
+export interface ComputeIsLyricLineActiveInput {
+	line: LyricLine;
+	lineIndex: number;
+	lyricLineKeyMap: Map<LyricLineKey, LyricLine>;
+	lyricLinesIndicies: WeakMap<LyricLine, number>;
+	bufferedLines: Set<number>;
+}
+
+/**
+ * 计算当前歌词行是否应被视为活跃可显示的行
+ */
+export function computeIsLyricLineActive(
+	input: ComputeIsLyricLineActiveInput,
+): boolean {
+	const {
+		line,
+		lineIndex,
+		bufferedLines,
+		lyricLineKeyMap: lyrlcLineKeyMap,
+		lyricLinesIndicies,
+	} = input;
+
+	// 如果是主行，那么只要它在缓冲区内就算活跃
+	if (line.parentLyricLineKey === undefined)
+		return bufferedLines.has(lineIndex);
+
+	// 如果是子行，那么只有在它的父行在缓冲区内时才算活跃
+	const parentLine = lyrlcLineKeyMap.get(line.parentLyricLineKey);
+	if (!parentLine) return false;
+
+	const parentIndex = lyricLinesIndicies.get(parentLine);
+	if (parentIndex === undefined) return false;
+
+	return bufferedLines.has(parentIndex);
+}
+
 /**
  * {@link computeLinePresentation} 的参数类型。
  *
@@ -201,8 +238,8 @@ export interface ComputeLinePresentationInput {
 	scrollToIndex: number;
 	/** 当前缓冲区（{@link PlayerTimelineState.bufferedLines}）中最靠后的歌词行索引 */
 	latestIndex: number;
-	/** 当前歌词行是否在缓冲集合内 */
-	hasBuffered: boolean;
+	/** 当前歌词行是否为活跃可显示行 */
+	isActiveLine: boolean;
 	/** 是否启用隐藏已播放行 */
 	hidePassedLines: boolean;
 	/** 是否处于播放状态 */
@@ -249,7 +286,7 @@ export function computeLinePresentation(
 		lineIndex,
 		scrollToIndex,
 		latestIndex,
-		hasBuffered,
+		isActiveLine,
 		hidePassedLines,
 		isPlaying,
 		isNonDynamic,
@@ -261,7 +298,7 @@ export function computeLinePresentation(
 	} = input;
 
 	const isActive =
-		hasBuffered || (lineIndex >= scrollToIndex && lineIndex < latestIndex);
+		isActiveLine || (lineIndex >= scrollToIndex && lineIndex < latestIndex);
 	const blurLevel = computeLineBlur({
 		enableBlur,
 		isUserScrolling,
@@ -280,12 +317,12 @@ export function computeLinePresentation(
 		) {
 			// 为了避免浏览器优化，这里使用了一个极小但不为零的值（几乎不可见）
 			targetOpacity = 1e-4;
-		} else if (hasBuffered) {
+		} else if (isActiveLine) {
 			targetOpacity = 0.85;
 		} else {
 			targetOpacity = isNonDynamic ? 0.2 : 1;
 		}
-	} else if (hasBuffered) {
+	} else if (isActiveLine) {
 		targetOpacity = 0.85;
 	} else {
 		targetOpacity = isNonDynamic ? 0.2 : 1;
@@ -294,7 +331,7 @@ export function computeLinePresentation(
 	const SCALE_ASPECT = enableScale ? 97 : 100;
 	let targetScale = 100;
 	if (!isActive && isPlaying) {
-		targetScale = line.isBG ? 75 : SCALE_ASPECT;
+		targetScale = line.parentLyricLineKey ? 75 : SCALE_ASPECT;
 	}
 
 	return {
@@ -356,4 +393,80 @@ export function computeLineBlur(input: ComputeLineBlurInput): number {
 	}
 
 	return isCompact ? blurLevel * 0.8 : blurLevel;
+}
+
+export interface ComputeScrollOffsetInput {
+	currentLyricLineObjects: LyricLineBase[];
+	lyricLinesSize: WeakMap<LyricLineBase, [number, number]>;
+	fallbackHeight: number;
+	targetAlignIndex: number;
+	isPlaying: boolean;
+}
+
+/**
+ * 计算当前歌词行下的滚动偏移量，以实现目标行的对齐。
+ *
+ * 通过累加目标行之前所有歌词行的高度，得到一个滚动偏移值，
+ * 使得目标行能够对齐到播放器的指定位置。
+ * 在播放状态下会跳过子行（例如对唱歌词的第二行），以保持主行对齐。
+ */
+export function computeScrollOffset(input: ComputeScrollOffsetInput): number {
+	const {
+		currentLyricLineObjects,
+		lyricLinesSize,
+		fallbackHeight,
+		isPlaying,
+		targetAlignIndex,
+	} = input;
+
+	let result = 0;
+
+	for (const line of currentLyricLineObjects.slice(0, targetAlignIndex)) {
+		const isSubLine = line.getLine().parentLyricLineKey !== undefined;
+		if (isSubLine && isPlaying) {
+			continue;
+		}
+		const lineHeight = lyricLinesSize.get(line)?.[1] ?? fallbackHeight;
+		result += lineHeight;
+	}
+
+	return result;
+}
+
+export interface ComputeShouldOccupyHeightInput {
+	line: LyricLine;
+	lyricLineKeyMap: Map<LyricLineKey, LyricLine>;
+	lyricLinesIndicies: WeakMap<LyricLine, number>;
+	bufferedLines: Set<number>;
+	isPresentationActive: boolean;
+	isPlaying: boolean;
+}
+
+/**
+ * 计算当前歌词是否需要占用高度空间，以排列歌词行，并步进 calcLayout 中的 curPos
+ */
+export function computeShouldOccupyHeight(
+	input: ComputeShouldOccupyHeightInput,
+): boolean {
+	const {
+		line,
+		lyricLineKeyMap: lyrlcLineKeyMap,
+		lyricLinesIndicies,
+		bufferedLines,
+		isPlaying,
+	} = input;
+
+	if (line.parentLyricLineKey === undefined) return true;
+
+	// 又或者当前播放器暂停的时候也会呈现
+	if (!isPlaying) return true;
+
+	// 如果是子行，那么只有在它的父行正在展示时呈现
+	const parentLine = lyrlcLineKeyMap.get(line.parentLyricLineKey);
+	if (!parentLine) return true;
+
+	const parentIndex = lyricLinesIndicies.get(parentLine);
+	if (parentIndex === undefined) return true;
+
+	return bufferedLines.has(parentIndex);
 }

--- a/packages/core/src/lyric-player/base/timeline.ts
+++ b/packages/core/src/lyric-player/base/timeline.ts
@@ -70,22 +70,8 @@ export function computePlayerTimeState(
 			removedHotIds.add(lastHotId);
 			continue;
 		}
-		if (line.isBG) continue;
-		const nextLine = processedLines[lastHotId + 1];
-		if (nextLine?.isBG) {
-			const nextMainLine = processedLines[lastHotId + 2];
-			const startTime = Math.min(line.startTime, nextLine.startTime);
-			const endTime = Math.min(
-				Math.max(line.endTime, nextMainLine?.startTime ?? Number.MAX_VALUE),
-				Math.max(line.endTime, nextLine.endTime),
-			);
-			if (time < startTime || endTime <= time) {
-				nextHotLines.delete(lastHotId);
-				removedHotIds.add(lastHotId);
-				nextHotLines.delete(lastHotId + 1);
-				removedHotIds.add(lastHotId + 1);
-			}
-		} else if (time < line.startTime || line.endTime <= time) {
+		if (line.parentLyricLineKey) continue;
+		if (time < line.startTime || line.endTime <= time) {
 			nextHotLines.delete(lastHotId);
 			removedHotIds.add(lastHotId);
 		}
@@ -93,7 +79,7 @@ export function computePlayerTimeState(
 
 	for (let id = 0; id < processedLines.length; id++) {
 		const line = processedLines[id];
-		if (!line || line.isBG) continue;
+		if (!line || line.parentLyricLineKey) continue;
 		if (
 			line.startTime <= time &&
 			line.endTime > time &&
@@ -101,10 +87,6 @@ export function computePlayerTimeState(
 		) {
 			nextHotLines.add(id);
 			addedIds.add(id);
-			if (processedLines[id + 1]?.isBG) {
-				nextHotLines.add(id + 1);
-				addedIds.add(id + 1);
-			}
 		}
 	}
 
@@ -165,10 +147,6 @@ export interface CommitPlayerTimeStateResult {
 	shouldLayout: boolean;
 	/** 提交后是否需要重置用户滚动状态 */
 	shouldResetScroll: boolean;
-	/** 需要启用的歌词行索引列表 */
-	linesToEnable: number[];
-	/** 需要禁用的歌词行索引列表 */
-	linesToDisable: number[];
 }
 
 /**
@@ -251,7 +229,5 @@ export function commitPlayerTimeState(
 	return {
 		shouldLayout,
 		shouldResetScroll,
-		linesToEnable,
-		linesToDisable: [...linesToDisable],
 	};
 }

--- a/packages/core/src/lyric-player/dom/index.ts
+++ b/packages/core/src/lyric-player/dom/index.ts
@@ -6,8 +6,8 @@
 
 import type { LyricLine } from "#interfaces";
 import "#styles/index.css";
-import type { LyricLineBase } from "#lyric/base/line.ts";
 import { LyricPlayerBase } from "#lyric/base/index.ts";
+import type { LyricLineBase } from "#lyric/base/line.ts";
 import styles from "#styles/lyric-player.module.css";
 import { LyricLineEl, type RawLyricLineMouseEvent } from "./lyric-line.ts";
 
@@ -54,7 +54,7 @@ export class DomLyricPlayer extends LyricPlayerBase {
 	readonly innerSize: [number, number] = [0, 0];
 	private readonly onLineClickedHandler = (e: RawLyricLineMouseEvent) => {
 		const evt = new LyricLineMouseEvent(
-			this.lyricLinesIndexes.get(e.line) ?? -1,
+			this.displayLyricLinesIndicies.get(e.line) ?? -1,
 			e.line,
 			e,
 		);
@@ -104,7 +104,7 @@ export class DomLyricPlayer extends LyricPlayerBase {
 	}
 
 	/**
-	 * 设置当前播放歌词，要注意传入后这个数组内的信息不得修改，否则会发生错误
+	 * 设置当前播放歌词，传入的歌词数组结构会被结构化克隆，并对其实行有关的歌词后处理操作
 	 * @param lines 歌词数组
 	 * @param initialTime 初始时间，默认为 0
 	 */
@@ -131,7 +131,8 @@ export class DomLyricPlayer extends LyricPlayerBase {
 			lineEl.addMouseEventListener("click", this.onLineClickedHandler);
 			lineEl.addMouseEventListener("contextmenu", this.onLineClickedHandler);
 			// 不立即挂载到 DOM，进入视图（含 overscan）后在 LyricLineEl 内部挂载
-			this.lyricLinesIndexes.set(lineEl, i);
+			this.displayLyricLinesIndicies.set(lineEl, i);
+			this.lyricLinesIndicies.set(line, i);
 			// 仍需建立元素到行对象的映射，供 ResizeObserver 使用
 			this.lyricLineElementMap.set(lineEl.getElement(), lineEl);
 			return lineEl;

--- a/packages/core/src/lyric-player/dom/lyric-line.ts
+++ b/packages/core/src/lyric-player/dom/lyric-line.ts
@@ -9,6 +9,7 @@ import { chunkAndSplitLyricWords } from "#utils/lyric-split-words.ts";
 import { createMatrix4, matrix4ToCSS, scaleMatrix4 } from "#utils/matrix.ts";
 import type { DomLyricPlayer } from ".";
 import { clamp, clamp01, clampPositive } from "#utils/clamp.ts";
+import { uid } from "uid";
 
 interface RealWord extends LyricWord {
 	mainElement: HTMLSpanElement;
@@ -98,12 +99,13 @@ export class LyricLineEl extends LyricLineBase {
 	constructor(
 		private lyricPlayer: DomLyricPlayer,
 		private lyricLine: LyricLine = {
+			key: uid(),
 			words: [],
 			translatedLyric: "",
 			romanLyric: "",
 			startTime: 0,
 			endTime: 0,
-			isBG: false,
+			parentLyricLineKey: undefined,
 			isDuet: false,
 		},
 	) {
@@ -111,8 +113,8 @@ export class LyricLineEl extends LyricLineBase {
 		this._prevParentEl = lyricPlayer.getElement();
 		lyricPlayer.resizeObserver.observe(this.element);
 		this.element.setAttribute("class", styles.lyricLine);
-		if (this.lyricLine.isBG) {
-			this.element.classList.add(styles.lyricBgLine);
+		if (this.lyricLine.parentLyricLineKey !== undefined) {
+			this.element.classList.add(styles.lyricChildLine);
 		}
 		if (this.lyricLine.isDuet) {
 			this.element.classList.add(styles.lyricDuetLine);
@@ -595,7 +597,7 @@ export class LyricLineEl extends LyricLineBase {
 		const delay = word.startTime - this.lyricLine.startTime;
 		const duration = Math.max(1000, word.endTime - word.startTime);
 		let up = 0.05;
-		if (this.lyricLine.isBG) {
+		if (this.lyricLine.parentLyricLineKey) {
 			up *= 2;
 		}
 		const a = wordEl.animate(
@@ -705,7 +707,7 @@ export class LyricLineEl extends LyricLineBase {
 					const x = (j + 1) / ANIMATION_FRAME_QUANTITY;
 					let y = Math.sin(x * Math.PI);
 					// y = x < 0.5 ? y : Math.max(y, 1.0);
-					if (this.lyricLine.isBG) {
+					if (this.lyricLine.parentLyricLineKey) {
 						y *= 2;
 					}
 

--- a/packages/core/src/styles/lyric-player.module.css
+++ b/packages/core/src/styles/lyric-player.module.css
@@ -33,19 +33,19 @@
 	}
 
 	&:has(> *):hover {
-		background-color: var(--amll-lp-hover-bg-color, #fff1);
-		/* box-shadow: 0 0 0 4px var(--amll-lp-hover-bg-color, #fff1); */
+		background-color: var(--amll-lp-hover-child-color, #fff1);
+		/* box-shadow: 0 0 0 4px var(--amll-lp-hover-sub-color, #fff1); */
 	}
 
 	&:has(> *):active {
-		background-color: var(--amll-lp-hover-bg-color, #ffffff05);
-		/* box-shadow: 0 0 0 var(--amll-lp-hover-bg-color, #fff1); */
+		background-color: var(--amll-lp-hover-child-color, #ffffff05);
+		/* box-shadow: 0 0 0 var(--amll-lp-hover-sub-color, #fff1); */
 	}
 }
 
-.lyricBgLine {
+.lyricChildLine {
 	opacity: 0.0001;
-	font-size: max(calc(1em * var(--amll-lp-bg-line-scale, 0.7)), 10px);
+	font-size: max(calc(1em * var(--amll-lp-child-line-scale, 0.7)), 10px);
 	transition:
 		opacity 0.25s,
 		scale 0.5s,
@@ -54,7 +54,10 @@
 		box-shadow 0.25s;
 	/* 因为字体大小缩小了，故内边距要和主行字体大小统一，行边距计算公式为 100% / font-size 转 em 单位 */
 	padding: 1vh
-		calc(var(--amll-lp-line-padding-x, 1em) / var(--amll-lp-bg-line-scale, 0.7));
+		calc(
+			var(--amll-lp-line-padding-x, 1em) /
+			var(--amll-lp-child-line-scale, 0.7)
+		);
 
 	.lyricMainLine {
 		padding: 1.2em 1em;
@@ -86,7 +89,7 @@
 		}
 	}
 
-	&:not(:global(.playing)) > .lyricBgLine {
+	&:not(:global(.playing)) > .lyricChildLine {
 		opacity: 0.4;
 	}
 }

--- a/packages/core/src/utils/optimize-lyric.ts
+++ b/packages/core/src/utils/optimize-lyric.ts
@@ -50,15 +50,17 @@ function resetLineTimestamps(lines: LyricLine[]) {
  */
 function convertExcessiveBackgroundLines(lines: LyricLine[]) {
 	let consecutiveBgCount = 0;
+	let lastMainLyric: LyricLine | undefined;
 
 	for (const line of lines) {
-		if (line.isBG) {
+		if (line.parentLyricLineKey) {
 			consecutiveBgCount++;
-			if (consecutiveBgCount > 1) {
-				line.isBG = false;
+			if (consecutiveBgCount > 1 && lastMainLyric) {
+				line.parentLyricLineKey = lastMainLyric.key;
 			}
 		} else {
 			consecutiveBgCount = 0;
+			lastMainLyric = line;
 		}
 	}
 }
@@ -71,10 +73,10 @@ function convertExcessiveBackgroundLines(lines: LyricLine[]) {
 function syncMainAndBackgroundLines(lines: LyricLine[]) {
 	for (let i = lines.length - 1; i >= 0; i--) {
 		const line = lines[i];
-		if (line.isBG) continue;
+		if (line.parentLyricLineKey) continue;
 
 		const nextLine = lines[i + 1];
-		if (nextLine?.isBG) {
+		if (nextLine?.parentLyricLineKey) {
 			const allWords = [...line.words, ...nextLine.words].filter(
 				(w) => w.word.trim().length > 0,
 			);
@@ -107,10 +109,13 @@ function syncMainAndBackgroundLines(lines: LyricLine[]) {
 function cleanUnintentionalOverlaps(lines: LyricLine[]) {
 	for (let i = 0; i < lines.length - 1; i++) {
 		const line = lines[i];
-		if (line.isBG) continue;
+		if (line.parentLyricLineKey) continue;
 
 		let nextMainIndex = i + 1;
-		while (nextMainIndex < lines.length && lines[nextMainIndex].isBG) {
+		while (
+			nextMainIndex < lines.length &&
+			lines[nextMainIndex].parentLyricLineKey
+		) {
 			nextMainIndex++;
 		}
 
@@ -130,7 +135,7 @@ function cleanUnintentionalOverlaps(lines: LyricLine[]) {
 					line.endTime = nextLine.startTime;
 
 					const attachedBgLine = lines[i + 1];
-					if (attachedBgLine?.isBG) {
+					if (attachedBgLine?.parentLyricLineKey) {
 						attachedBgLine.endTime = nextLine.startTime;
 					}
 				}
@@ -155,7 +160,7 @@ function tryAdvanceStartTime(lines: LyricLine[]) {
 
 	for (let i = 0; i < lines.length; i++) {
 		const line = lines[i];
-		if (line.isBG) continue;
+		if (line.parentLyricLineKey) continue;
 
 		const originalStartTime = line.startTime;
 		const originalEndTime = line.endTime;
@@ -187,7 +192,7 @@ function tryAdvanceStartTime(lines: LyricLine[]) {
 		}
 
 		const nextLine = lines[i + 1];
-		if (nextLine?.isBG) {
+		if (nextLine?.parentLyricLineKey) {
 			nextLine.startTime = line.startTime;
 		}
 

--- a/packages/docs/astro.config.ts
+++ b/packages/docs/astro.config.ts
@@ -173,7 +173,8 @@ export default defineConfig({
 				},
 			],
 			editLink: {
-				baseUrl: "https://github.com/amll-dev/applemusic-like-lyrics/blob/main/packages/docs/",
+				baseUrl:
+					"https://github.com/amll-dev/applemusic-like-lyrics/blob/main/packages/docs/",
 			},
 		}),
 	],

--- a/packages/lyric/src/formats/lyl.ts
+++ b/packages/lyric/src/formats/lyl.ts
@@ -37,7 +37,7 @@ export function parseLyl(lyl: string): LyricLine[] {
 		const backgroundMatch = text.match(bgRegex);
 		const isBG = Boolean(backgroundMatch);
 		const textContent = (backgroundMatch ? backgroundMatch[1] : text).trim();
-		if(!textContent) continue;
+		if (!textContent) continue;
 
 		lyricLines.push(
 			createLine({

--- a/packages/playground/core/src/assets/index.tailwind.css
+++ b/packages/playground/core/src/assets/index.tailwind.css
@@ -54,7 +54,7 @@
 	--card-foreground: oklch(0.145 0 0);
 	--popover: oklch(1 0 0);
 	--popover-foreground: oklch(0.145 0 0);
-	--primary: oklch(0.629 0.215 25.963);
+	--primary: oklch(67.62% 0.204 24.42);
 	--primary-foreground: oklch(0.969 0.015 12.422);
 	--secondary: oklch(0.967 0.001 286.375);
 	--secondary-foreground: oklch(0.21 0.006 285.885);
@@ -84,7 +84,7 @@
 	--card-foreground: oklch(0.985 0 0);
 	--popover: oklch(0.205 0 0);
 	--popover-foreground: oklch(0.985 0 0);
-	--primary: oklch(0.582 0.193 26.976);
+	--primary: oklch(67.62% 0.204 24.42);
 	--primary-foreground: oklch(0.969 0.015 12.422);
 	--secondary: oklch(0.281 0 271.152);
 	--secondary-foreground: oklch(0.985 0 0);

--- a/packages/playground/core/src/components/SidebarShell.vue
+++ b/packages/playground/core/src/components/SidebarShell.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import amllLogoSvg from "@/assets/amll-logo.svg";
 import {
 	Sidebar,
 	SidebarContent,
@@ -11,6 +10,7 @@ import AudioPlayer from "./AudioController.vue";
 import BackgroundController from "./BackgroundController.vue";
 import LyricController from "./LyricController.vue";
 import SourceController from "./SourceController.vue";
+import amllLogoSvg from "@/assets/amll-logo.svg";
 
 const props = withDefaults(defineProps<SidebarProps>(), {});
 const coreVersion = __AMLL_CORE_VERSION__;
@@ -23,7 +23,7 @@ const coreVersion = __AMLL_CORE_VERSION__;
 				<div
 					class="flex aspect-square size-8 items-center justify-center rounded-md bg-primary text-sidebar-primary-foreground overflow-hidden"
 				>
-					<img :src="amllLogoSvg">
+					<img :src="amllLogoSvg" class="rounded-lg">
 				</div>
 				<div class="flex flex-col gap-1 leading-none">
 					<span class="font-medium"> AMLL Playground </span>

--- a/packages/playground/core/src/components/SourceController.vue
+++ b/packages/playground/core/src/components/SourceController.vue
@@ -6,6 +6,7 @@ import {
 	MusicIcon,
 	RefreshCwIcon,
 	TextAlignStartIcon,
+	FileJsonIcon,
 } from "lucide-vue-next";
 import { computed } from "vue";
 import { Button } from "@/components/ui/button";
@@ -13,6 +14,7 @@ import { Input } from "@/components/ui/input";
 import { Separator } from "@/components/ui/separator";
 import { extractCoverBlob } from "@/lib/extract-cover";
 import { usePlayerStore } from "@/stores/player";
+import TextArea from "./ui/textarea/TextArea.vue";
 
 const player = usePlayerStore();
 
@@ -129,6 +131,16 @@ async function openLocalMusicFile(file: File): Promise<void> {
 			<p v-if="player.background.error" class="text-xs text-destructive">
 				{{ player.background.error }}
 			</p>
+		</section>
+
+		<Separator />
+
+		<section class="space-y-2.5">
+			<h3 class="text-sm font-bold flex items-center gap-1">
+				<FileJsonIcon :size="16" />
+				LyricLine 数组 JSON
+			</h3>
+			<TextArea id="lyriclines-json" placeholder="LyricLine 数组 JSON" />
 		</section>
 	</div>
 </template>

--- a/packages/playground/core/src/components/ui/textarea/TextArea.vue
+++ b/packages/playground/core/src/components/ui/textarea/TextArea.vue
@@ -1,0 +1,31 @@
+<script setup lang="ts">
+import type { HTMLAttributes } from 'vue'
+import { useVModel } from '@vueuse/core'
+import { cn } from '@/lib/utils'
+
+const props = defineProps<{
+  defaultValue?: string | number
+  modelValue?: string | number
+  class?: HTMLAttributes['class']
+}>()
+
+const emits = defineEmits<{
+  (e: 'update:modelValue', payload: string | number): void
+}>()
+
+const modelValue = useVModel(props, 'modelValue', emits, {
+  passive: true,
+  defaultValue: props.defaultValue,
+})
+</script>
+
+<template>
+  <textarea
+    v-model="modelValue"
+    data-slot="input"
+    :class="cn(
+      'dark:bg-input/30 border-input focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border bg-transparent px-2.5 py-1 text-base shadow-xs transition-[color,box-shadow] file:h-7 file:text-sm file:font-medium focus-visible:ring-3 aria-invalid:ring-3 md:text-sm w-full min-w-0 min-h-[7em] outline-none file:inline-flex file:border-0 file:bg-transparent file:text-foreground placeholder:text-muted-foreground disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50',
+      props.class,
+    )"
+  ></textarea>
+</template>

--- a/packages/playground/core/src/components/ui/textarea/index.ts
+++ b/packages/playground/core/src/components/ui/textarea/index.ts
@@ -1,0 +1,1 @@
+export { default as TextArea } from './TextArea.vue'

--- a/packages/ttml/package.json
+++ b/packages/ttml/package.json
@@ -54,5 +54,8 @@
 		"tsdown": "catalog:",
 		"typedoc": "catalog:",
 		"vitest": "catalog:"
+	},
+	"dependencies": {
+		"uid": "^2.0.2"
 	}
 }

--- a/packages/ttml/src/types/amll.ts
+++ b/packages/ttml/src/types/amll.ts
@@ -27,10 +27,17 @@ export interface LyricWordBase {
 	word: string;
 }
 
+/** 歌词行的唯一键值，对于子行歌词相关功能来说需要提供以正确查询父歌词行 */
+export type AmllLyricLineKey = string | number;
+
 /**
  * 一行歌词，存储多个单词
  */
 export interface AmllLyricLine {
+	/**
+	 * 这个歌词行的唯一键值，对于子行歌词相关功能来说需要提供以正确查询父歌词行
+	 */
+	key: AmllLyricLineKey;
 	/**
 	 * 该行的所有单词
 	 */
@@ -44,9 +51,11 @@ export interface AmllLyricLine {
 	 */
 	romanLyric: string;
 	/**
-	 * 该行是否为背景歌词行
+	 * 该歌词行的父级歌词行键值
+	 * 在 AMLL 中，如果这个歌词存在一个父级歌词，则这个歌词就会成为子歌词（又称背景歌词）
+	 * 且在排版的时候，会根据开始时间早于或晚于父级歌词来考虑将其排序到主歌词行的前面或者后面
 	 */
-	isBG: boolean;
+	parentLyricLineKey?: AmllLyricLineKey;
 	/**
 	 * 该行是否为对唱歌词行（即歌词行靠右对齐）
 	 */

--- a/packages/ttml/src/utils/amll-converter.ts
+++ b/packages/ttml/src/utils/amll-converter.ts
@@ -3,9 +3,11 @@
  * @module amll-converter
  */
 
+import { uid } from "uid";
 import { Elements, Values } from "../constants";
 import type {
 	AmllLyricLine,
+	AmllLyricLineKey,
 	AmllLyricResult,
 	AmllLyricWord,
 	AmllMetadata,
@@ -29,7 +31,7 @@ export function toAmllLyrics(
 
 	const convertToAmllLine = (
 		source: LyricBase,
-		isBG: boolean,
+		parentLyricLineKey: AmllLyricLineKey | undefined,
 		isDuet: boolean,
 	): AmllLyricLine => {
 		let amllWords: AmllLyricWord[] = [];
@@ -99,10 +101,11 @@ export function toAmllLyrics(
 		}
 
 		return {
+			key: uid(),
 			words: amllWords,
 			translatedLyric: transText,
 			romanLyric: romanText,
-			isBG: isBG,
+			parentLyricLineKey,
 			isDuet: isDuet,
 			startTime: source.startTime,
 			endTime: source.endTime,
@@ -141,13 +144,13 @@ export function toAmllLyrics(
 			}
 		}
 
-		const amllMain = convertToAmllLine(line, false, currentIsDuet);
+		const amllMain = convertToAmllLine(line, undefined, currentIsDuet);
 		amllLines.push(amllMain);
 
 		if (line.backgroundVocal) {
 			const simpleBg = convertToAmllLine(
 				line.backgroundVocal,
-				true,
+				amllMain.key,
 				currentIsDuet,
 			);
 			amllLines.push(simpleBg);
@@ -355,7 +358,7 @@ export function toTTMLResult(
 			];
 		}
 
-		if (amllLine.isBG) {
+		if (amllLine.parentLyricLineKey) {
 			if (currentMainLine && !currentMainLine.backgroundVocal) {
 				currentMainLine.backgroundVocal = lyricBase;
 			} else {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -125,6 +125,9 @@ importers:
       gl-matrix:
         specifier: 4.0.0-beta.2
         version: 4.0.0-beta.2
+      uid:
+        specifier: ^2.0.2
+        version: 2.0.2
     devDependencies:
       '@biomejs/biome':
         specifier: 'catalog:'
@@ -666,6 +669,10 @@ importers:
         version: 4.11.0(typedoc@0.28.19(typescript@5.9.3))
 
   packages/ttml:
+    dependencies:
+      uid:
+        specifier: ^2.0.2
+        version: 2.0.2
     devDependencies:
       '@biomejs/biome':
         specifier: 'catalog:'
@@ -1900,6 +1907,10 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@lukeed/csprng@1.1.0':
+    resolution: {integrity: sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==}
+    engines: {node: '>=8'}
 
   '@mdx-js/mdx@3.1.1':
     resolution: {integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==}
@@ -7073,6 +7084,10 @@ packages:
   ufo@1.6.4:
     resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
 
+  uid@2.0.2:
+    resolution: {integrity: sha512-u3xV3X7uzvi5b1MncmZo3i2Aw222Zk1keqLA1YkHldREkAhAqi65wuPfe7lHx8H/Wzy+8CE7S7uS3jekIM5s8g==}
+    engines: {node: '>=8'}
+
   uint8array-extras@1.5.0:
     resolution: {integrity: sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==}
     engines: {node: '>=18'}
@@ -8898,6 +8913,8 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@lukeed/csprng@1.1.0': {}
 
   '@mdx-js/mdx@3.1.1':
     dependencies:
@@ -14834,6 +14851,10 @@ snapshots:
   uc.micro@2.1.0: {}
 
   ufo@1.6.4: {}
+
+  uid@2.0.2:
+    dependencies:
+      '@lukeed/csprng': 1.1.0
 
   uint8array-extras@1.5.0: {}
 


### PR DESCRIPTION
为了考虑通用化概念和缓解部分代码的复杂度，我考虑将背景歌词从纯粹的 `isBG` 字段真假与否迁移到子歌词行概念，可以实现：

- #504 提及的前置背景歌词行
- 一定程度上对排版算法的逻辑改善
  - 可以借助新的键值快速索引到歌词行，而不需要另存上一行的歌词行逻辑，缓解复杂度
- ~~虽然咱们不考虑，但是理论上可以实现无限级联的子歌词（画面比较离谱所以不考虑做成那个样子）~~

同时为此添加歌词行键值概念，此键为 `number | string` 类型，在通过 `setLyricLines` 传入时需要确保歌词行之间独一无二，以及在子歌词行中通过 `parentLyricLineKey` 字段指定子歌词行的所属父歌词行

可能需要对这个功能进行一定的兼容性考虑？

目前进度：

- [x] core 模块的基本实现
- [ ] lyric/ttml 模块的适配（和项目协作脱节一段时间了不太会改歌词模块了，~~摇个人~~）
- [ ] 其他边界情况检查

另外还引入了部分杂项代码修正：
- 为 Playground 更换了新的 Logo
- 为 Playground 调整了主题配色