### PR TITLE
refactor: 引入歌词组来包装主歌词和背景人声 & 前置背景人声

### DIFF
--- a/.nx/version-plans/version-plan-1778931004430.md
+++ b/.nx/version-plans/version-plan-1778931004430.md
@@ -1,0 +1,5 @@
+---
+core-bundle: patch
+---
+
+refactor: 引入歌词组来包装主歌词和背景人声 & 前置背景人声

--- a/packages/core/src/lyric-player/base/group.ts
+++ b/packages/core/src/lyric-player/base/group.ts
@@ -7,6 +7,7 @@ export interface LyricPlayerFlags {
 	getEnableSpring(): boolean;
 	getEnableScale(): boolean;
 	getIsPlaying(): boolean;
+	getAlwaysPostpositionBackground(): boolean;
 }
 
 export abstract class LyricLineGroupBase<
@@ -63,7 +64,11 @@ export abstract class LyricLineGroupBase<
 		this.setLineTransformations(force, delay);
 
 		const enableSpring = this.lyricPlayer.getEnableSpring();
-		const hiddenSlideY = this.isBgFirst ? 80 : -80;
+		const alwaysPostposition =
+			this.lyricPlayer.getAlwaysPostpositionBackground();
+		const shouldBgFirst = alwaysPostposition ? false : this.isBgFirst;
+		const hiddenSlideY = shouldBgFirst ? 80 : -80;
+
 		const isPlaying = this.lyricPlayer.getIsPlaying();
 
 		const targetBgSlideY = isActive || !isPlaying ? 0 : hiddenSlideY;

--- a/packages/core/src/lyric-player/base/group.ts
+++ b/packages/core/src/lyric-player/base/group.ts
@@ -102,9 +102,11 @@ export abstract class LyricLineGroupBase<
 	abstract get isInSight(): boolean;
 
 	update(delta: number): void {
-		this.posY.update(delta);
-		this.bgSlideY.update(delta);
-		this.renderStyles();
+		if (this.lyricPlayer.getEnableSpring()) {
+			this.posY.update(delta);
+			this.bgSlideY.update(delta);
+			this.renderStyles();
+		}
 
 		this.mainLine.update(delta);
 		this.bgLine?.update(delta);

--- a/packages/core/src/lyric-player/base/group.ts
+++ b/packages/core/src/lyric-player/base/group.ts
@@ -1,0 +1,128 @@
+import type { Disposable } from "#interfaces";
+import { Spring } from "#utils/spring.ts";
+import { LyricLineRenderMode } from "./consts.ts";
+import type { LyricLineBase } from "./line.ts";
+
+export abstract class LyricLineGroupBase<
+	T extends LyricLineBase = LyricLineBase,
+> implements Disposable
+{
+	public posY: Spring = new Spring(0);
+	public bgSlideY: Spring = new Spring(-80);
+	public top = 0;
+	public delay = 0;
+
+	public isActive = false;
+	public opacity = 1;
+	public blur = 0;
+
+	public isBgFirst = false;
+
+	constructor(
+		public mainLine: T,
+		public bgLine?: T | undefined,
+	) {}
+
+	get startTime(): number {
+		// 优化歌词时 `syncMainAndBackgroundLines` 已经把时间同步好了，直接读取主歌词的即可
+		// 要是用户关掉了这个优化，我们认为在这种情况下主歌词和背景人声显示不同步是符合用户预期的
+		return this.mainLine.getLine().startTime;
+	}
+
+	get endTime(): number {
+		return this.mainLine.getLine().endTime;
+	}
+
+	onLineSizeChange(size: [number, number]): void {
+		this.mainLine.onLineSizeChange(size);
+		this.bgLine?.onLineSizeChange(size);
+	}
+
+	setTransform(
+		top: number,
+		force: boolean,
+		delay: number,
+		enableSpring: boolean,
+		isActive: boolean,
+		opacity: number,
+		blur: number,
+		enableScale: boolean,
+		isPlaying: boolean,
+	): void {
+		this.top = top;
+		this.delay = delay;
+		this.isActive = isActive;
+		this.opacity = opacity;
+		this.blur = blur;
+
+		this.setLineTransformations(force, delay, enableScale, isPlaying);
+
+		const hiddenSlideY = this.isBgFirst ? 80 : -80;
+
+		if (force || !enableSpring) {
+			this.posY.setPosition(top);
+			this.bgSlideY.setPosition(isActive ? 0 : hiddenSlideY);
+			this.renderStyles();
+		} else {
+			this.posY.setTargetPosition(top, delay);
+			this.bgSlideY.setTargetPosition(isActive ? 0 : hiddenSlideY, delay);
+		}
+	}
+
+	private setLineTransformations(
+		force: boolean,
+		delay: number,
+		enableScale: boolean,
+		isPlaying: boolean,
+	) {
+		const renderMode = this.isActive
+			? LyricLineRenderMode.GRADIENT
+			: LyricLineRenderMode.SOLID;
+
+		const SCALE_ASPECT = enableScale ? 97 : 100;
+		let mainScale = 100;
+		if (!this.isActive && isPlaying) {
+			mainScale = SCALE_ASPECT;
+		}
+		this.mainLine.setTransform(mainScale, 1, 0, force, delay, renderMode);
+
+		let bgScale = 100;
+		if (!this.isActive && isPlaying) {
+			bgScale = 75;
+		}
+		this.bgLine?.setTransform(bgScale, 1, 0, force, delay, renderMode);
+	}
+
+	protected abstract renderStyles(): void;
+
+	abstract get isInSight(): boolean;
+
+	update(delta: number): void {
+		this.posY.update(delta);
+		this.bgSlideY.update(delta);
+		this.renderStyles();
+
+		this.mainLine.update(delta);
+		this.bgLine?.update(delta);
+	}
+
+	rebuildAllLines(): void {
+		this.mainLine.rebuildElement();
+		this.bgLine?.rebuildElement();
+	}
+
+	enable(time?: number, shouldPlay?: boolean): void {
+		this.mainLine.enable(time, shouldPlay);
+		this.bgLine?.enable(time, shouldPlay);
+	}
+
+	disable(): void {
+		this.mainLine.disable();
+		this.bgLine?.disable();
+	}
+
+	dispose(): void {
+		this.mainLine.dispose();
+		this.bgLine?.dispose();
+	}
+}

--- a/packages/core/src/lyric-player/base/group.ts
+++ b/packages/core/src/lyric-player/base/group.ts
@@ -3,10 +3,18 @@ import { Spring } from "#utils/spring.ts";
 import { LyricLineRenderMode } from "./consts.ts";
 import type { LyricLineBase } from "./line.ts";
 
+export interface LyricPlayerFlags {
+	getEnableSpring(): boolean;
+	getEnableScale(): boolean;
+	getIsPlaying(): boolean;
+}
+
 export abstract class LyricLineGroupBase<
 	T extends LyricLineBase = LyricLineBase,
 > implements Disposable
 {
+	protected abstract readonly lyricPlayer: LyricPlayerFlags;
+
 	public posY: Spring = new Spring(0);
 	public bgSlideY: Spring = new Spring(-80);
 	public top = 0;
@@ -42,12 +50,9 @@ export abstract class LyricLineGroupBase<
 		top: number,
 		force: boolean,
 		delay: number,
-		enableSpring: boolean,
 		isActive: boolean,
 		opacity: number,
 		blur: number,
-		enableScale: boolean,
-		isPlaying: boolean,
 	): void {
 		this.top = top;
 		this.delay = delay;
@@ -55,8 +60,9 @@ export abstract class LyricLineGroupBase<
 		this.opacity = opacity;
 		this.blur = blur;
 
-		this.setLineTransformations(force, delay, enableScale, isPlaying);
+		this.setLineTransformations(force, delay);
 
+		const enableSpring = this.lyricPlayer.getEnableSpring();
 		const hiddenSlideY = this.isBgFirst ? 80 : -80;
 
 		if (force || !enableSpring) {
@@ -69,12 +75,10 @@ export abstract class LyricLineGroupBase<
 		}
 	}
 
-	private setLineTransformations(
-		force: boolean,
-		delay: number,
-		enableScale: boolean,
-		isPlaying: boolean,
-	) {
+	private setLineTransformations(force: boolean, delay: number) {
+		const enableScale = this.lyricPlayer.getEnableScale();
+		const isPlaying = this.lyricPlayer.getIsPlaying();
+
 		const renderMode = this.isActive
 			? LyricLineRenderMode.GRADIENT
 			: LyricLineRenderMode.SOLID;

--- a/packages/core/src/lyric-player/base/group.ts
+++ b/packages/core/src/lyric-player/base/group.ts
@@ -64,14 +64,17 @@ export abstract class LyricLineGroupBase<
 
 		const enableSpring = this.lyricPlayer.getEnableSpring();
 		const hiddenSlideY = this.isBgFirst ? 80 : -80;
+		const isPlaying = this.lyricPlayer.getIsPlaying();
+
+		const targetBgSlideY = isActive || !isPlaying ? 0 : hiddenSlideY;
 
 		if (force || !enableSpring) {
 			this.posY.setPosition(top);
-			this.bgSlideY.setPosition(isActive ? 0 : hiddenSlideY);
+			this.bgSlideY.setPosition(targetBgSlideY);
 			this.renderStyles();
 		} else {
 			this.posY.setTargetPosition(top, delay);
-			this.bgSlideY.setTargetPosition(isActive ? 0 : hiddenSlideY, delay);
+			this.bgSlideY.setTargetPosition(targetBgSlideY, delay);
 		}
 	}
 

--- a/packages/core/src/lyric-player/base/index.ts
+++ b/packages/core/src/lyric-player/base/index.ts
@@ -664,12 +664,9 @@ export abstract class LyricPlayerBase
 				curPos,
 				force,
 				delay,
-				this.getEnableSpring(),
 				presentation.isActive,
 				presentation.targetOpacity,
 				presentation.blurLevel,
-				this.enableScale,
-				this.timelineState.isPlaying,
 			);
 
 			curPos += this.lyricGroupSize.get(group)?.[1] ?? LINE_HEIGHT_FALLBACK;

--- a/packages/core/src/lyric-player/base/index.ts
+++ b/packages/core/src/lyric-player/base/index.ts
@@ -97,6 +97,9 @@ export abstract class LyricPlayerBase
 	protected isPageVisible = true;
 	protected optimizeOptions: OptimizeLyricOptions = {};
 
+	/** 是否强制让背景人声行始终后置（即始终在主歌词下方显示，不前置背景人声） */
+	protected alwaysPostpositionBackground = false;
+
 	protected posXSpringParams: Partial<SpringParams> = {
 		mass: 1,
 		damping: 10,
@@ -812,6 +815,29 @@ export abstract class LyricPlayerBase
 	 */
 	getCurrentTime(): number {
 		return this.timelineState.currentTime;
+	}
+
+	/**
+	 * 设置是否让背景人声行始终后置显示
+	 *
+	 * 默认情况下，如果背景歌词开始时间早于主歌词，会在主歌词上方展示；
+	 * 如果设置为 `true`，则无论时间顺序如何，背景歌词都会始终在主歌词下方展示
+	 * @param enable 是否启用始终后置
+	 */
+	setAlwaysPostpositionBackground(enable: boolean): void {
+		if (this.alwaysPostpositionBackground === enable) {
+			return;
+		}
+
+		this.alwaysPostpositionBackground = enable;
+
+		this.rebuildLyricLines();
+		this.calcLayout();
+	}
+
+	/** 获取当前是否设置了让背景人声行始终后置显示 */
+	getAlwaysPostpositionBackground(): boolean {
+		return this.alwaysPostpositionBackground;
 	}
 
 	getElement(): HTMLElement {

--- a/packages/core/src/lyric-player/base/index.ts
+++ b/packages/core/src/lyric-player/base/index.ts
@@ -599,7 +599,9 @@ export abstract class LyricPlayerBase
 
 		const targetLineHeight = curGroup
 			? (this.lyricGroupSize.get(curGroup)?.[1] ?? LINE_HEIGHT_FALLBACK)
-			: 0;
+			: isBottomFocused
+				? this.bottomLine.lineSize[1]
+				: 0;
 
 		if (targetLineHeight > 0) {
 			switch (this.layoutState.alignAnchor) {

--- a/packages/core/src/lyric-player/base/index.ts
+++ b/packages/core/src/lyric-player/base/index.ts
@@ -91,7 +91,7 @@ export abstract class LyricPlayerBase
 		isScrolled: false,
 		isUserScrolling: false,
 	};
-	protected currentLyricGroups: LyricLineGroupBase[] = [];
+	public currentLyricGroups: LyricLineGroupBase[] = [];
 	lyricGroupSize: WeakMap<LyricLineGroupBase, [number, number]> = new WeakMap();
 	readonly size: [number, number] = [0, 0];
 	protected isPageVisible = true;

--- a/packages/core/src/lyric-player/base/index.ts
+++ b/packages/core/src/lyric-player/base/index.ts
@@ -7,15 +7,17 @@ import type {
 	OptimizeLyricOptions,
 } from "#interfaces";
 import styles from "#styles/lyric-player.module.css";
+import { clampPositive } from "#utils/clamp.ts";
 import { optimizeLyricLines } from "#utils/optimize-lyric.ts";
 import type { SpringParams } from "#utils/spring.ts";
 import { InterludeDots } from "../dom/interlude-dots.ts";
 import { BottomLineEl } from "./bottom-line.ts";
 import { LayoutAlignAnchor, MaskObsceneWordsMode } from "./consts.ts";
+import type { LyricLineGroupBase } from "./group.ts";
 import {
-	computeLineBlur,
-	computeLinePresentation,
 	computeCurrentInterlude,
+	computeGroupPresentation,
+	computeLineBlur,
 	computeLinePosYSpringParams,
 	type PlayerLayoutState,
 } from "./layout.ts";
@@ -30,10 +32,9 @@ import {
 	computePlayerTimeState,
 	type PlayerTimelineState,
 } from "./timeline.ts";
-import { clampPositive } from "#utils/clamp.ts";
 
-export type { LyricLineBase } from "./line.ts";
 export type { PlayerLayoutState } from "./layout.ts";
+export type { LyricLineBase } from "./line.ts";
 export type { PlayerScrollState } from "./scroll.ts";
 export type { PlayerTimelineState } from "./timeline.ts";
 
@@ -52,19 +53,16 @@ export abstract class LyricPlayerBase
 	protected timelineState: PlayerTimelineState = {
 		currentTime: 0,
 		lastCurrentTime: 0,
-		hotLines: new Set(),
-		bufferedLines: new Set(),
+		hotGroups: new Set(),
+		bufferedGroups: new Set(),
 		scrollToIndex: 0,
 		isSeeking: false,
 		isPlaying: true,
 		initialLayoutFinished: false,
 	};
 	/** @internal */
-	lyricLinesSize: WeakMap<LyricLineBase, [number, number]> = new WeakMap();
-	/** @internal */
-	lyricLineElementMap: WeakMap<Element, LyricLineBase> = new WeakMap();
+	lyricGroupElementMap: WeakMap<Element, LyricLineGroupBase> = new WeakMap();
 	protected currentLyricLines: LyricLine[] = [];
-	// protected currentLyricLineObjects: LyricLineBase[] = [];
 	protected processedLines: LyricLine[] = [];
 	protected lyricLinesIndexes: WeakMap<LyricLineBase, number> = new WeakMap();
 	protected isNonDynamic = false;
@@ -93,7 +91,8 @@ export abstract class LyricPlayerBase
 		isScrolled: false,
 		isUserScrolling: false,
 	};
-	protected currentLyricLineObjects: LyricLineBase[] = [];
+	protected currentLyricGroups: LyricLineGroupBase[] = [];
+	lyricGroupSize: WeakMap<LyricLineGroupBase, [number, number]> = new WeakMap();
 	readonly size: [number, number] = [0, 0];
 	protected isPageVisible = true;
 	protected optimizeOptions: OptimizeLyricOptions = {};
@@ -152,19 +151,20 @@ export abstract class LyricPlayerBase
 					shouldRelayout = true;
 				}
 			} else {
-				const lineObj = this.lyricLineElementMap.get(entry.target);
-				if (lineObj) {
+				const groupObj = this.lyricGroupElementMap.get(entry.target);
+				if (groupObj) {
 					const newSize: [number, number] = [
 						entry.target.clientWidth,
 						entry.target.clientHeight,
 					];
-					const oldSize: [number, number] = this.lyricLinesSize.get(
-						lineObj,
+
+					const oldSize: [number, number] = this.lyricGroupSize.get(
+						groupObj,
 					) ?? [0, 0];
 
 					if (newSize[0] !== oldSize[0] || newSize[1] !== oldSize[1]) {
-						this.lyricLinesSize.set(lineObj, newSize);
-						lineObj.onLineSizeChange(newSize);
+						this.lyricGroupSize.set(groupObj, newSize);
+						groupObj.onLineSizeChange(newSize);
 						shouldRelayout = true;
 					}
 				}
@@ -307,8 +307,8 @@ export abstract class LyricPlayerBase
 	}
 
 	rebuildLyricLines(): void {
-		for (const lineObj of this.currentLyricLineObjects) {
-			lineObj.rebuildElement();
+		for (const group of this.currentLyricGroups) {
+			group.rebuildAllLines();
 		}
 	}
 	/**
@@ -429,6 +429,7 @@ export abstract class LyricPlayerBase
 		this.timelineState.initialLayoutFinished = true;
 		this.timelineState.lastCurrentTime = initialTime;
 		this.timelineState.currentTime = initialTime;
+
 		this.currentLyricLines = structuredClone(lines);
 		this.processedLines = structuredClone(this.currentLyricLines);
 		optimizeLyricLines(this.processedLines, this.optimizeOptions);
@@ -443,14 +444,14 @@ export abstract class LyricPlayerBase
 
 		this.hasDuetLine = this.processedLines.some((line) => line.isDuet);
 
-		for (const line of this.currentLyricLineObjects) {
-			line.dispose();
+		for (const group of this.currentLyricGroups) {
+			group.dispose();
 		}
+		this.currentLyricGroups = [];
 
 		this.interludeDots.setInterlude(undefined);
-		this.timelineState.hotLines.clear();
-		this.timelineState.bufferedLines.clear();
-		this.setCurrentTime(0, true);
+		this.timelineState.hotGroups.clear();
+		this.timelineState.bufferedGroups.clear();
 
 		if (import.meta.env.DEV) {
 			console.log("歌词处理完成", this);
@@ -490,7 +491,7 @@ export abstract class LyricPlayerBase
 
 		const stateResult = computePlayerTimeState({
 			time,
-			processedLines: this.processedLines,
+			currentGroups: this.currentLyricGroups,
 			timelineState,
 		});
 
@@ -499,16 +500,16 @@ export abstract class LyricPlayerBase
 		const commitResult = commitPlayerTimeState({
 			timelineState: timelineState,
 			time,
-			processedLines: this.processedLines,
+			currentGroups: this.currentLyricGroups,
 			hasBottomContent,
 			stateResult,
 		});
 
-		for (const id of commitResult.linesToDisable)
-			this.currentLyricLineObjects[id]?.disable();
+		for (const id of commitResult.groupsToDisable)
+			this.currentLyricGroups[id]?.disable();
 
-		for (const id of commitResult.linesToEnable)
-			this.currentLyricLineObjects[id]?.enable();
+		for (const id of commitResult.groupsToEnable)
+			this.currentLyricGroups[id]?.enable();
 
 		if (commitResult.shouldResetScroll) this.resetScroll();
 		if (commitResult.shouldLayout) this.calcLayout();
@@ -535,7 +536,7 @@ export abstract class LyricPlayerBase
 		const interlude = computeCurrentInterlude({
 			currentTime: this.timelineState.currentTime,
 			scrollToIndex: this.timelineState.scrollToIndex,
-			processedLines: this.processedLines,
+			currentGroups: this.currentLyricGroups,
 		});
 		const isInterludeActive = !!interlude;
 
@@ -547,7 +548,7 @@ export abstract class LyricPlayerBase
 
 			const springParams = computeLinePosYSpringParams({
 				enabled: this.getEnableSpring(),
-				processedLines: this.processedLines,
+				currentGroups: this.currentLyricGroups,
 				scrollToIndex: this.timelineState.scrollToIndex,
 				isSeeking: this.timelineState.isSeeking,
 				isInterludeActive,
@@ -578,33 +579,27 @@ export abstract class LyricPlayerBase
 		}
 		// 避免一开始就让所有歌词行挤在一起
 		const LINE_HEIGHT_FALLBACK = this.size[1] / 5;
-		const scrollOffset = this.currentLyricLineObjects
+		const scrollOffset = this.currentLyricGroups
 			.slice(0, targetAlignIndex)
 			.reduce(
-				(acc, el) =>
-					acc +
-					(el.getLine().isBG && this.timelineState.isPlaying
-						? 0
-						: (this.lyricLinesSize.get(el)?.[1] ?? LINE_HEIGHT_FALLBACK)),
+				(acc, group) =>
+					acc + (this.lyricGroupSize.get(group)?.[1] ?? LINE_HEIGHT_FALLBACK),
 				0,
 			);
+
 		this.scrollState.scrollBoundary.minOffset = -scrollOffset;
 		curPos -= scrollOffset;
 		curPos += this.size[1] * this.layoutState.alignPosition;
-		const curLine = this.currentLyricLineObjects[targetAlignIndex];
+
+		const curGroup = this.currentLyricGroups[targetAlignIndex];
 		this.layoutState.targetAlignIndex = targetAlignIndex;
 
-		const isBottomFocused =
-			targetAlignIndex === this.currentLyricLineObjects.length;
+		const isBottomFocused = targetAlignIndex === this.currentLyricGroups.length;
 		this.bottomLine.setFocused(isBottomFocused);
 
-		let targetLineHeight = 0;
-		if (curLine) {
-			targetLineHeight =
-				this.lyricLinesSize.get(curLine)?.[1] ?? LINE_HEIGHT_FALLBACK;
-		} else if (isBottomFocused) {
-			targetLineHeight = this.bottomLine.lineSize[1];
-		}
+		const targetLineHeight = curGroup
+			? (this.lyricGroupSize.get(curGroup)?.[1] ?? LINE_HEIGHT_FALLBACK)
+			: 0;
 
 		if (targetLineHeight > 0) {
 			switch (this.layoutState.alignAnchor) {
@@ -619,13 +614,13 @@ export abstract class LyricPlayerBase
 			}
 		}
 
-		const latestIndex = Math.max(...this.timelineState.bufferedLines);
+		const latestIndex = Math.max(...this.timelineState.bufferedGroups);
 		let delay = 0;
 		let baseDelay = sync ? 0 : 0.05;
 		let setDots = false;
-		this.currentLyricLineObjects.forEach((lineObj, i) => {
-			const hasBuffered = this.timelineState.bufferedLines.has(i);
-			const line = lineObj.getLine();
+
+		this.currentLyricGroups.forEach((group, i) => {
+			const hasBuffered = this.timelineState.bufferedGroups.has(i);
 
 			const shouldShowDots = interlude && i === interlude.anchorLineIndex + 1;
 
@@ -651,50 +646,43 @@ export abstract class LyricPlayerBase
 				curPos += dotMargin;
 			}
 
-			const presentation = computeLinePresentation({
-				line,
-				lineIndex: i,
+			const presentation = computeGroupPresentation({
+				groupIndex: i,
 				scrollToIndex: this.timelineState.scrollToIndex,
 				latestIndex,
 				hasBuffered,
 				hidePassedLines: this.hidePassedLines,
 				isPlaying: this.timelineState.isPlaying,
 				isNonDynamic: this.isNonDynamic,
-				enableScale: this.enableScale,
 				enableBlur: this.enableBlur,
 				isUserScrolling: this.scrollState.isUserScrolling,
 				isCompact: window.innerWidth <= 1024,
 				interlude,
 			});
 
-			lineObj.setTransform(
+			group.setTransform(
 				curPos,
-				presentation.targetScale,
-				presentation.targetOpacity,
-				presentation.blurLevel,
 				force,
 				delay,
-				presentation.renderMode,
+				this.getEnableSpring(),
+				presentation.isActive,
+				presentation.targetOpacity,
+				presentation.blurLevel,
+				this.enableScale,
+				this.timelineState.isPlaying,
 			);
 
-			if (
-				line.isBG &&
-				(presentation.isActive || !this.timelineState.isPlaying)
-			) {
-				curPos += this.lyricLinesSize.get(lineObj)?.[1] ?? LINE_HEIGHT_FALLBACK;
-			} else if (!line.isBG) {
-				curPos += this.lyricLinesSize.get(lineObj)?.[1] ?? LINE_HEIGHT_FALLBACK;
-			}
-			if (curPos >= 0 && !this.timelineState.isSeeking) {
-				if (!line.isBG) delay += baseDelay;
+			curPos += this.lyricGroupSize.get(group)?.[1] ?? LINE_HEIGHT_FALLBACK;
 
+			if (curPos >= 0 && !this.timelineState.isSeeking) {
+				delay += baseDelay;
 				if (i >= this.timelineState.scrollToIndex) baseDelay /= 1.05;
 			}
 		});
 		this.scrollState.scrollBoundary.maxOffset =
 			curPos + this.scrollState.scrollOffset - this.size[1] / 2;
 
-		const bottomIndex = this.currentLyricLineObjects.length;
+		const bottomIndex = this.currentLyricGroups.length;
 		const finalBottomBlur = computeLineBlur({
 			enableBlur: this.enableBlur,
 			isUserScrolling: this.scrollState.isUserScrolling,
@@ -726,8 +714,9 @@ export abstract class LyricPlayerBase
 			...params,
 		};
 		this.bottomLine.lineTransforms.posY.updateParams(this.posYSpringParams);
-		for (const line of this.currentLyricLineObjects) {
-			line.lineTransforms.posY.updateParams(this.posYSpringParams);
+		for (const group of this.currentLyricGroups) {
+			group.posY.updateParams(this.posYSpringParams);
+			group.bgSlideY.updateParams(this.posYSpringParams);
 		}
 	}
 	/**
@@ -744,12 +733,12 @@ export abstract class LyricPlayerBase
 			...this.scaleForBGSpringParams,
 			...params,
 		};
-		for (const lineObj of this.currentLyricLineObjects) {
-			if (lineObj.getLine().isBG) {
-				lineObj.lineTransforms.scale.updateParams(this.scaleForBGSpringParams);
-			} else {
-				lineObj.lineTransforms.scale.updateParams(this.scaleSpringParams);
-			}
+		for (const group of this.currentLyricGroups) {
+			group.mainLine.lineTransforms.scale.updateParams(this.scaleSpringParams);
+
+			group.bgLine?.lineTransforms.scale.updateParams(
+				this.scaleForBGSpringParams,
+			);
 		}
 	}
 	/**

--- a/packages/core/src/lyric-player/base/layout.ts
+++ b/packages/core/src/lyric-player/base/layout.ts
@@ -2,6 +2,7 @@ import { clamp } from "#utils/clamp.ts";
 import type { SpringParams } from "#utils/spring.ts";
 import type { LayoutAlignAnchor } from "./consts.ts";
 import type { LyricLineGroupBase } from "./group.ts";
+import type { PlayerTimelineState } from "./timeline.ts";
 
 /**
  * 播放器布局状态。
@@ -192,7 +193,7 @@ export interface ComputeGroupPresentationInput {
 	groupIndex: number;
 	/** 当前目标对齐行索引 */
 	scrollToIndex: number;
-	/** 当前缓冲区（{@link PlayerTimelineState.bufferedLines}）中最靠后的歌词行索引 */
+	/** 当前缓冲区（{@link PlayerTimelineState.bufferedGroups}）中最靠后的歌词行索引 */
 	latestIndex: number;
 	/** 当前歌词行是否在缓冲集合内 */
 	hasBuffered: boolean;
@@ -212,7 +213,7 @@ export interface ComputeGroupPresentationInput {
 	interlude?: PlayerInterlude;
 }
 
-/** {@link ComputeGroupPresentation} 的结果类型 */
+/** {@link computeGroupPresentation} 的结果类型 */
 export interface ComputeGroupPresentationResult {
 	/** 当前歌词行是否应视为活跃行 */
 	isActive: boolean;
@@ -226,7 +227,7 @@ export interface ComputeGroupPresentationResult {
  * 计算一组歌词在当前布局中的视觉呈现参数。
  *
  * 根据播放状态、缓冲状态、布局模式与间奏信息，
- * 生成一行歌词最终应使用的 opacity、scale、blur 和 render mode。
+ * 生成一组歌词最终应使用的活跃状态、不透明度与模糊值。
  */
 export function computeGroupPresentation(
 	input: ComputeGroupPresentationInput,

--- a/packages/core/src/lyric-player/base/layout.ts
+++ b/packages/core/src/lyric-player/base/layout.ts
@@ -1,8 +1,7 @@
-import type { LyricLine } from "#interfaces";
 import { clamp } from "#utils/clamp.ts";
 import type { SpringParams } from "#utils/spring.ts";
-import { type LayoutAlignAnchor, LyricLineRenderMode } from "./consts.ts";
-import type { PlayerTimelineState } from "./timeline.ts";
+import type { LayoutAlignAnchor } from "./consts.ts";
+import type { LyricLineGroupBase } from "./group.ts";
 
 /**
  * 播放器布局状态。
@@ -47,7 +46,7 @@ export interface PlayerInterlude {
 export interface ComputeCurrentInterludeInput {
 	currentTime: number;
 	scrollToIndex: number;
-	processedLines: LyricLine[];
+	currentGroups: LyricLineGroupBase[];
 }
 
 /**
@@ -61,27 +60,25 @@ export function computeCurrentInterlude(
 ): PlayerInterlude | undefined {
 	const currentTime = input.currentTime + 20;
 	const currentIndex = input.scrollToIndex;
-	const lines = input.processedLines;
+	const groups = input.currentGroups;
 
 	const checkGap = (k: number): PlayerInterlude | undefined => {
-		if (k < -1 || k >= lines.length - 1) return undefined;
+		if (k < -1 || k >= groups.length - 1) return undefined;
 
-		const prevLine = k === -1 ? null : lines[k];
-		const nextLine = lines[k + 1];
+		const prevGroup = k === -1 ? null : groups[k];
+		const nextGroup = groups[k + 1];
 
-		const gapStart = prevLine ? prevLine.endTime : 0;
-		const gapEnd = Math.max(gapStart, nextLine.startTime - 250);
+		const gapStart = prevGroup ? prevGroup.endTime : 0;
+		const gapEnd = Math.max(gapStart, nextGroup.startTime - 250);
 
-		if (gapEnd - gapStart < 4000) {
-			return undefined;
-		}
+		if (gapEnd - gapStart < 4000) return undefined;
 
 		if (gapEnd > currentTime && gapStart < currentTime) {
 			return {
 				startTime: Math.max(gapStart, currentTime),
 				endTime: gapEnd,
 				anchorLineIndex: k,
-				isNextDuet: nextLine.isDuet,
+				isNextDuet: nextGroup.mainLine.getLine().isDuet,
 			};
 		}
 		return undefined;
@@ -102,7 +99,7 @@ export interface ComputeLinePosYSpringParamsInput {
 	/** 是否启用弹簧动画 */
 	enabled: boolean;
 	/** 当前用于布局的歌词数据 */
-	processedLines: LyricLine[];
+	currentGroups: LyricLineGroupBase[];
 	/** 当前目标对齐行索引 */
 	scrollToIndex: number;
 	/** 是否处于 seeking 模式 */
@@ -131,13 +128,13 @@ export function computeLinePosYSpringParams(
 ): ComputeLinePosYSpringParamsResult {
 	const {
 		enabled,
-		processedLines,
+		currentGroups,
 		scrollToIndex,
 		isSeeking,
 		isInterludeActive,
 	} = input;
 
-	if (!enabled || processedLines.length === 0) {
+	if (!enabled || currentGroups.length === 0) {
 		return { shouldUpdate: false };
 	}
 
@@ -148,16 +145,14 @@ export function computeLinePosYSpringParams(
 		};
 	}
 
-	const currentLine = processedLines[scrollToIndex];
-	const prevLine = processedLines[scrollToIndex - 1];
+	const currentGroup = currentGroups[scrollToIndex];
+	const prevGroup = currentGroups[scrollToIndex - 1];
 
-	if (!currentLine || !prevLine) {
+	if (!currentGroup || !prevGroup) {
 		return { shouldUpdate: false };
 	}
 
-	const interval =
-		currentLine.startTime -
-		(prevLine.words[0]?.startTime ?? prevLine.startTime);
+	const interval = currentGroup.startTime - prevGroup.startTime;
 
 	const MIN_INTERVAL = 100;
 	const MAX_INTERVAL = 800;
@@ -187,16 +182,14 @@ export function computeLinePosYSpringParams(
 }
 
 /**
- * {@link computeLinePresentation} 的参数类型。
+ * {@link computeGroupPresentation} 的参数类型。
  *
  * 描述一行歌词在当前布局上下文中的全部关键信息，
  * 用于计算其视觉呈现结果。
  */
-export interface ComputeLinePresentationInput {
-	/** 要计算的歌词行 */
-	line: LyricLine;
-	/** 当前歌词行索引 */
-	lineIndex: number;
+export interface ComputeGroupPresentationInput {
+	/** 当前歌词组索引 */
+	groupIndex: number;
 	/** 当前目标对齐行索引 */
 	scrollToIndex: number;
 	/** 当前缓冲区（{@link PlayerTimelineState.bufferedLines}）中最靠后的歌词行索引 */
@@ -209,8 +202,6 @@ export interface ComputeLinePresentationInput {
 	isPlaying: boolean;
 	/** 当前歌词是否为非逐词歌词 */
 	isNonDynamic: boolean;
-	/** 是否启用缩放效果 */
-	enableScale: boolean;
 	/** 是否启用模糊效果 */
 	enableBlur: boolean;
 	/** 是否正在进行滚动交互 */
@@ -221,39 +212,33 @@ export interface ComputeLinePresentationInput {
 	interlude?: PlayerInterlude;
 }
 
-/** {@link computeLinePresentation} 的结果类型 */
-export interface ComputeLinePresentationResult {
+/** {@link ComputeGroupPresentation} 的结果类型 */
+export interface ComputeGroupPresentationResult {
 	/** 当前歌词行是否应视为活跃行 */
 	isActive: boolean;
 	/** 当前歌词行的目标不透明度 */
 	targetOpacity: number;
-	/** 当前歌词行的目标缩放值 */
-	targetScale: number;
 	/** 当前歌词行的目标模糊值 */
 	blurLevel: number;
-	/** 当前歌词行应使用的渲染模式 */
-	renderMode: LyricLineRenderMode;
 }
 
 /**
- * 计算单行歌词在当前布局中的视觉呈现参数。
+ * 计算一组歌词在当前布局中的视觉呈现参数。
  *
  * 根据播放状态、缓冲状态、布局模式与间奏信息，
  * 生成一行歌词最终应使用的 opacity、scale、blur 和 render mode。
  */
-export function computeLinePresentation(
-	input: ComputeLinePresentationInput,
-): ComputeLinePresentationResult {
+export function computeGroupPresentation(
+	input: ComputeGroupPresentationInput,
+): ComputeGroupPresentationResult {
 	const {
-		line,
-		lineIndex,
+		groupIndex,
 		scrollToIndex,
 		latestIndex,
 		hasBuffered,
 		hidePassedLines,
 		isPlaying,
 		isNonDynamic,
-		enableScale,
 		enableBlur,
 		isUserScrolling,
 		isCompact,
@@ -261,12 +246,13 @@ export function computeLinePresentation(
 	} = input;
 
 	const isActive =
-		hasBuffered || (lineIndex >= scrollToIndex && lineIndex < latestIndex);
+		hasBuffered || (groupIndex >= scrollToIndex && groupIndex < latestIndex);
+
 	const blurLevel = computeLineBlur({
 		enableBlur,
 		isUserScrolling,
 		isActive,
-		itemIndex: lineIndex,
+		itemIndex: groupIndex,
 		scrollToIndex,
 		latestIndex,
 		isCompact,
@@ -275,7 +261,8 @@ export function computeLinePresentation(
 	let targetOpacity: number;
 	if (hidePassedLines) {
 		if (
-			lineIndex < (interlude ? interlude.anchorLineIndex + 1 : scrollToIndex) &&
+			groupIndex <
+				(interlude ? interlude.anchorLineIndex + 1 : scrollToIndex) &&
 			isPlaying
 		) {
 			// 为了避免浏览器优化，这里使用了一个极小但不为零的值（几乎不可见）
@@ -291,21 +278,7 @@ export function computeLinePresentation(
 		targetOpacity = isNonDynamic ? 0.2 : 1;
 	}
 
-	const SCALE_ASPECT = enableScale ? 97 : 100;
-	let targetScale = 100;
-	if (!isActive && isPlaying) {
-		targetScale = line.isBG ? 75 : SCALE_ASPECT;
-	}
-
-	return {
-		isActive,
-		targetOpacity,
-		targetScale,
-		blurLevel,
-		renderMode: isActive
-			? LyricLineRenderMode.GRADIENT
-			: LyricLineRenderMode.SOLID,
-	};
+	return { isActive, targetOpacity, blurLevel };
 }
 
 /** {@link computeLineBlur} 的参数类型 */

--- a/packages/core/src/lyric-player/base/line.ts
+++ b/packages/core/src/lyric-player/base/line.ts
@@ -4,7 +4,6 @@ import { Spring } from "#utils/spring.ts";
 import { LyricLineRenderMode } from "./consts.ts";
 
 interface LineTransforms {
-	posY: Spring;
 	scale: Spring;
 }
 
@@ -19,7 +18,6 @@ export abstract class LyricLineBase extends EventTarget implements Disposable {
 	protected opacity = 1;
 	protected delay = 0;
 	readonly lineTransforms: LineTransforms = {
-		posY: new Spring(0),
 		scale: new Spring(100),
 	};
 
@@ -45,9 +43,9 @@ export abstract class LyricLineBase extends EventTarget implements Disposable {
 	abstract disable(): void;
 	abstract resume(): void;
 	abstract pause(): void;
-	onLineSizeChange(_size: [number, number]): void {}
+	abstract onLineSizeChange(size: [number, number]): void;
+
 	setTransform(
-		top: number = this.top,
 		scale: number = this.scale,
 		opacity: number = this.opacity,
 		blur: number = this.blur,
@@ -55,7 +53,6 @@ export abstract class LyricLineBase extends EventTarget implements Disposable {
 		delay = 0,
 		_mode: LyricLineRenderMode = LyricLineRenderMode.SOLID,
 	): void {
-		this.top = top;
 		this.scale = scale;
 		this.opacity = opacity;
 		this.blur = blur;

--- a/packages/core/src/lyric-player/base/timeline.ts
+++ b/packages/core/src/lyric-player/base/timeline.ts
@@ -1,21 +1,21 @@
-import type { LyricLine } from "#interfaces";
 import { eqSet } from "#utils/eq-set.ts";
+import type { LyricLineGroupBase } from "./group.ts";
 
 /**
  * 播放时间线状态。
  *
- * 描述播放器在时间轴上的当前位置，当前处于激活状态的歌词行信息
+ * 描述播放器在时间轴上的当前位置，当前处于激活状态的歌词组信息
  */
 export interface PlayerTimelineState {
 	/** 当前播放时间，单位为毫秒 */
 	currentTime: number;
 	/** 上一次提交到时间线状态的播放时间，单位为毫秒 */
 	lastCurrentTime: number;
-	/** 热行：当前时间 {@link currentTime} 正在命中的行（含主行+可能的背景行） */
-	hotLines: Set<number>;
-	/** 缓冲行：UI 上还保持激活表现的行，通常包含热行，并包含刚结束仍在过渡中的行 */
-	bufferedLines: Set<number>;
-	/** 当前应滚动对齐到的歌词行索引 */
+	/** 热行：当前时间 {@link currentTime} 正在命中的组（含主行+可能的背景行） */
+	hotGroups: Set<number>;
+	/** 缓冲组：UI 上还保持激活表现的组索引，通常包含热组，和刚结束仍在过渡中的组 */
+	bufferedGroups: Set<number>;
+	/** 当前应滚动对齐到的歌词组索引 */
 	scrollToIndex: number;
 	/** 是否正在拖拽进度条。若是，更新时丢弃缓冲行，并根据当前时间直接计算热行 */
 	isSeeking: boolean;
@@ -28,14 +28,14 @@ export interface PlayerTimelineState {
 /** {@link computePlayerTimeState} 的参数类型 */
 export interface ComputePlayerTimeStateInput {
 	time: number;
-	processedLines: LyricLine[];
+	currentGroups: LyricLineGroupBase[];
 	timelineState: Readonly<PlayerTimelineState>;
 }
 
 /** {@link computePlayerTimeState} 的返回类型 */
 export interface ComputePlayerTimeStateResult {
-	/** 计算后的新热行集合 */
-	nextHotLines: Set<number>;
+	/** 计算后的新热组集合 */
+	nextHotGroups: Set<number>;
 	/** 需要新加入热行集合的行索引 */
 	addedIds: Set<number>;
 	/** 需要从热行集合中移除的行索引 */
@@ -55,67 +55,45 @@ export function computePlayerTimeState(
 ): ComputePlayerTimeStateResult {
 	const {
 		time,
-		processedLines,
-		timelineState: { hotLines, bufferedLines },
+		currentGroups,
+		timelineState: { hotGroups, bufferedGroups },
 	} = input;
-	const nextHotLines = new Set(hotLines);
+
+	const nextHotGroups = new Set(hotGroups);
 	const addedIds = new Set<number>();
 	const removedHotIds = new Set<number>();
 	const removedBufferedIds = new Set<number>();
 
-	for (const lastHotId of hotLines) {
-		const line = processedLines[lastHotId];
-		if (!line) {
-			nextHotLines.delete(lastHotId);
-			removedHotIds.add(lastHotId);
-			continue;
-		}
-		if (line.isBG) continue;
-		const nextLine = processedLines[lastHotId + 1];
-		if (nextLine?.isBG) {
-			const nextMainLine = processedLines[lastHotId + 2];
-			const startTime = Math.min(line.startTime, nextLine.startTime);
-			const endTime = Math.min(
-				Math.max(line.endTime, nextMainLine?.startTime ?? Number.MAX_VALUE),
-				Math.max(line.endTime, nextLine.endTime),
-			);
-			if (time < startTime || endTime <= time) {
-				nextHotLines.delete(lastHotId);
-				removedHotIds.add(lastHotId);
-				nextHotLines.delete(lastHotId + 1);
-				removedHotIds.add(lastHotId + 1);
-			}
-		} else if (time < line.startTime || line.endTime <= time) {
-			nextHotLines.delete(lastHotId);
+	for (const lastHotId of hotGroups) {
+		const group = currentGroups[lastHotId];
+		if (!group || time < group.startTime || group.endTime <= time) {
+			nextHotGroups.delete(lastHotId);
 			removedHotIds.add(lastHotId);
 		}
 	}
 
-	for (let id = 0; id < processedLines.length; id++) {
-		const line = processedLines[id];
-		if (!line || line.isBG) continue;
+	for (let id = 0; id < currentGroups.length; id++) {
+		const group = currentGroups[id];
+		if (!group) continue;
+
 		if (
-			line.startTime <= time &&
-			line.endTime > time &&
-			!nextHotLines.has(id)
+			group.startTime <= time &&
+			group.endTime > time &&
+			!nextHotGroups.has(id)
 		) {
-			nextHotLines.add(id);
+			nextHotGroups.add(id);
 			addedIds.add(id);
-			if (processedLines[id + 1]?.isBG) {
-				nextHotLines.add(id + 1);
-				addedIds.add(id + 1);
-			}
 		}
 	}
 
-	for (const id of bufferedLines) {
-		if (!nextHotLines.has(id)) {
+	for (const id of bufferedGroups) {
+		if (!nextHotGroups.has(id)) {
 			removedBufferedIds.add(id);
 		}
 	}
 
 	return {
-		nextHotLines,
+		nextHotGroups,
 		addedIds,
 		removedHotIds,
 		removedBufferedIds,
@@ -130,14 +108,16 @@ export function computePlayerTimeState(
  */
 export function pickScrollToIndexForSeek(
 	time: number,
-	processedLines: LyricLine[],
-	bufferedLines: ReadonlySet<number>,
+	currentGroups: LyricLineGroupBase[],
+	bufferedGroups: ReadonlySet<number>,
 ): number {
-	if (bufferedLines.size > 0) {
-		return Math.min(...bufferedLines);
+	if (bufferedGroups.size > 0) {
+		return Math.min(...bufferedGroups);
 	}
-	const foundIndex = processedLines.findIndex((line) => line.startTime >= time);
-	return foundIndex === -1 ? processedLines.length : foundIndex;
+	const foundIndex = currentGroups.findIndex(
+		(group) => group.startTime >= time,
+	);
+	return foundIndex === -1 ? currentGroups.length : foundIndex;
 }
 
 /**
@@ -152,7 +132,7 @@ export interface CommitPlayerTimeStateInput {
 	/** 当前播放时间，单位为毫秒 */
 	time: number;
 	/** 当前用于计算的歌词数据 */
-	processedLines: LyricLine[];
+	currentGroups: LyricLineGroupBase[];
 	/** 底部附加区域当前是否有可见内容 */
 	hasBottomContent: boolean;
 	/** 由 {@link computePlayerTimeState} 得到的状态转移结果 */
@@ -165,10 +145,10 @@ export interface CommitPlayerTimeStateResult {
 	shouldLayout: boolean;
 	/** 提交后是否需要重置用户滚动状态 */
 	shouldResetScroll: boolean;
-	/** 需要启用的歌词行索引列表 */
-	linesToEnable: number[];
-	/** 需要禁用的歌词行索引列表 */
-	linesToDisable: number[];
+	/** 需要启用的歌词组索引列表 */
+	groupsToEnable: number[];
+	/** 需要禁用的歌词组索引列表 */
+	groupsToDisable: number[];
 }
 
 /**
@@ -181,64 +161,63 @@ export interface CommitPlayerTimeStateResult {
 export function commitPlayerTimeState(
 	input: CommitPlayerTimeStateInput,
 ): CommitPlayerTimeStateResult {
-	const { timelineState, time, processedLines, hasBottomContent, stateResult } =
+	const { timelineState, time, currentGroups, hasBottomContent, stateResult } =
 		input;
 	const { addedIds, removedHotIds, removedBufferedIds } = stateResult;
 	const { isSeeking } = timelineState;
 
 	timelineState.currentTime = time;
-	timelineState.hotLines = stateResult.nextHotLines;
+	timelineState.hotGroups = stateResult.nextHotGroups;
 
 	let shouldLayout = false;
 	let shouldResetScroll = false;
-	const linesToEnable: number[] = [];
-	const linesToDisable = new Set<number>();
+	const groupsToEnable: number[] = [];
+	const groupsToDisable = new Set<number>();
 
 	if (isSeeking) {
-		timelineState.bufferedLines = new Set([...timelineState.hotLines]);
+		timelineState.bufferedGroups = new Set([...timelineState.hotGroups]);
 		timelineState.scrollToIndex = pickScrollToIndexForSeek(
 			time,
-			processedLines,
-			timelineState.bufferedLines,
+			currentGroups,
+			timelineState.bufferedGroups,
 		);
-		for (const id of removedHotIds) linesToDisable.add(id);
-		for (const id of timelineState.hotLines) linesToEnable.push(id);
-		for (const id of removedBufferedIds) linesToDisable.add(id);
+		for (const id of removedHotIds) groupsToDisable.add(id);
+		for (const id of timelineState.hotGroups) groupsToEnable.push(id);
+		for (const id of removedBufferedIds) groupsToDisable.add(id);
 
 		shouldResetScroll = true;
 		shouldLayout = true;
 	} else if (addedIds.size > 0) {
 		for (const id of addedIds) {
-			timelineState.bufferedLines.add(id);
-			linesToEnable.push(id);
+			timelineState.bufferedGroups.add(id);
+			groupsToEnable.push(id);
 		}
 		for (const id of removedBufferedIds) {
-			timelineState.bufferedLines.delete(id);
-			linesToDisable.add(id);
+			timelineState.bufferedGroups.delete(id);
+			groupsToDisable.add(id);
 		}
-		if (timelineState.bufferedLines.size > 0) {
-			timelineState.scrollToIndex = Math.min(...timelineState.bufferedLines);
+		if (timelineState.bufferedGroups.size > 0) {
+			timelineState.scrollToIndex = Math.min(...timelineState.bufferedGroups);
 		}
 		shouldLayout = true;
 	} else if (
 		removedBufferedIds.size > 0 &&
-		eqSet(removedBufferedIds, timelineState.bufferedLines)
+		eqSet(removedBufferedIds, timelineState.bufferedGroups)
 	) {
-		for (const id of timelineState.bufferedLines) {
-			if (timelineState.hotLines.has(id)) continue;
-			timelineState.bufferedLines.delete(id);
-			linesToDisable.add(id);
+		for (const id of timelineState.bufferedGroups) {
+			if (timelineState.hotGroups.has(id)) continue;
+			timelineState.bufferedGroups.delete(id);
+			groupsToDisable.add(id);
 		}
 		shouldLayout = true;
 	}
 
-	if (timelineState.bufferedLines.size === 0 && processedLines.length > 0) {
-		const lastLine = processedLines[processedLines.length - 1];
-		if (time >= lastLine.endTime) {
+	if (timelineState.bufferedGroups.size === 0 && currentGroups.length > 0) {
+		const lastGroup = currentGroups[currentGroups.length - 1];
+		if (time >= lastGroup.endTime) {
 			const targetIndex = hasBottomContent
-				? processedLines.length
-				: processedLines.length - 1;
-
+				? currentGroups.length
+				: currentGroups.length - 1;
 			if (timelineState.scrollToIndex !== targetIndex) {
 				timelineState.scrollToIndex = targetIndex;
 				shouldLayout = true;
@@ -251,7 +230,7 @@ export function commitPlayerTimeState(
 	return {
 		shouldLayout,
 		shouldResetScroll,
-		linesToEnable,
-		linesToDisable: [...linesToDisable],
+		groupsToEnable,
+		groupsToDisable: [...groupsToDisable],
 	};
 }

--- a/packages/core/src/lyric-player/base/timeline.ts
+++ b/packages/core/src/lyric-player/base/timeline.ts
@@ -36,11 +36,11 @@ export interface ComputePlayerTimeStateInput {
 export interface ComputePlayerTimeStateResult {
 	/** 计算后的新热组集合 */
 	nextHotGroups: Set<number>;
-	/** 需要新加入热行集合的行索引 */
+	/** 需要新加入热组集合的组索引 */
 	addedIds: Set<number>;
-	/** 需要从热行集合中移除的行索引 */
+	/** 需要从热组集合中移除的组索引 */
 	removedHotIds: Set<number>;
-	/** 需要从缓冲行集合中移除的行索引 */
+	/** 需要从缓冲组集合中移除的组索引 */
 	removedBufferedIds: Set<number>;
 }
 

--- a/packages/core/src/lyric-player/dom/index.ts
+++ b/packages/core/src/lyric-player/dom/index.ts
@@ -6,9 +6,10 @@
 
 import type { LyricLine } from "#interfaces";
 import "#styles/index.css";
-import type { LyricLineBase } from "#lyric/base/line.ts";
 import { LyricPlayerBase } from "#lyric/base/index.ts";
+import type { LyricLineBase } from "#lyric/base/line.ts";
 import styles from "#styles/lyric-player.module.css";
+import { LyricLineGroup } from "./lyric-group.ts";
 import { LyricLineEl, type RawLyricLineMouseEvent } from "./lyric-line.ts";
 
 /**
@@ -38,7 +39,7 @@ export type LyricLineMouseEventListener = (evt: LyricLineMouseEvent) => void;
  * 尽可能贴切 Apple Music for iPad 的歌词效果设计，且做了力所能及的优化措施
  */
 export class DomLyricPlayer extends LyricPlayerBase {
-	override currentLyricLineObjects: LyricLineEl[] = [];
+	override currentLyricGroups: LyricLineGroup[] = [];
 
 	override onResize(): void {
 		const computedStyles = getComputedStyle(this.element);
@@ -98,8 +99,9 @@ export class DomLyricPlayer extends LyricPlayerBase {
 
 	override setWordFadeWidth(value = 0.5): void {
 		super.setWordFadeWidth(value);
-		for (const el of this.currentLyricLineObjects) {
-			el.updateMaskImageSync();
+		for (const group of this.currentLyricGroups) {
+			group.mainLine.updateMaskImageSync();
+			group.bgLine?.updateMaskImageSync();
 		}
 	}
 
@@ -119,29 +121,43 @@ export class DomLyricPlayer extends LyricPlayerBase {
 			this.element.style.setProperty("--amll-player-time", `${initialTime}`);
 		}
 
-		for (const line of this.currentLyricLineObjects) {
-			line.removeMouseEventListener("click", this.onLineClickedHandler);
-			line.removeMouseEventListener("contextmenu", this.onLineClickedHandler);
-			line.dispose();
-		}
+		for (const group of this.currentLyricGroups) {
+			const linesToDispose = [group.mainLine, group.bgLine].filter(
+				(line) => !!line,
+			);
 
-		// 创建新的歌词行元素
-		this.currentLyricLineObjects = this.processedLines.map((line, i) => {
+			for (const line of linesToDispose) {
+				line.removeMouseEventListener("click", this.onLineClickedHandler);
+				line.removeMouseEventListener("contextmenu", this.onLineClickedHandler);
+			}
+			group.dispose();
+		}
+		this.currentLyricGroups = [];
+
+		let currentGroup: LyricLineGroup | null = null;
+
+		for (let i = 0; i < this.processedLines.length; i++) {
+			const line = this.processedLines[i];
 			const lineEl = new LyricLineEl(this, line);
+
 			lineEl.addMouseEventListener("click", this.onLineClickedHandler);
 			lineEl.addMouseEventListener("contextmenu", this.onLineClickedHandler);
-			// 不立即挂载到 DOM，进入视图（含 overscan）后在 LyricLineEl 内部挂载
+
 			this.lyricLinesIndexes.set(lineEl, i);
-			// 仍需建立元素到行对象的映射，供 ResizeObserver 使用
-			this.lyricLineElementMap.set(lineEl.getElement(), lineEl);
-			return lineEl;
-		});
+
+			if (!line.isBG || !currentGroup) {
+				currentGroup = new LyricLineGroup(this, lineEl);
+				this.currentLyricGroups.push(currentGroup);
+				this.lyricGroupElementMap.set(currentGroup.element, currentGroup);
+			} else {
+				currentGroup.addBgLine(lineEl);
+			}
+		}
 
 		this.setLinePosXSpringParams({});
 		this.setLinePosYSpringParams({});
 		this.setLineScaleSpringParams({});
 		this.calcLayout(true);
-		// 触发一次更新以便立即挂载在视区/overscan 内的行元素
 		this.update(0);
 	}
 
@@ -149,8 +165,9 @@ export class DomLyricPlayer extends LyricPlayerBase {
 		super.pause();
 		this.element.classList.remove("playing");
 		this.interludeDots.pause();
-		for (const line of this.currentLyricLineObjects) {
-			line.pause();
+		for (const group of this.currentLyricGroups) {
+			group.mainLine.pause();
+			group.bgLine?.pause();
 		}
 	}
 
@@ -158,8 +175,9 @@ export class DomLyricPlayer extends LyricPlayerBase {
 		super.resume();
 		this.element.classList.add("playing");
 		this.interludeDots.resume();
-		for (const line of this.currentLyricLineObjects) {
-			line.resume();
+		for (const group of this.currentLyricGroups) {
+			group.mainLine.resume();
+			group.bgLine?.resume();
 		}
 	}
 
@@ -174,16 +192,16 @@ export class DomLyricPlayer extends LyricPlayerBase {
 		}
 		if (!this.isPageVisible) return;
 		const deltaS = delta / 1000;
-		for (const line of this.currentLyricLineObjects) {
-			line.update(deltaS);
+		for (const group of this.currentLyricGroups) {
+			group.update(deltaS);
 		}
 	}
 
 	override dispose(): void {
 		super.dispose();
 		this.element.remove();
-		for (const el of this.currentLyricLineObjects) {
-			el.dispose();
+		for (const group of this.currentLyricGroups) {
+			group.dispose();
 		}
 		this.bottomLine.dispose();
 		this.interludeDots.dispose();

--- a/packages/core/src/lyric-player/dom/index.ts
+++ b/packages/core/src/lyric-player/dom/index.ts
@@ -164,7 +164,7 @@ export class DomLyricPlayer extends LyricPlayerBase {
 
 	override pause(): void {
 		super.pause();
-		this.element.classList.remove("playing");
+		this.element.classList.remove(styles.playing);
 		this.interludeDots.pause();
 		for (const group of this.currentLyricGroups) {
 			group.mainLine.pause();
@@ -174,7 +174,7 @@ export class DomLyricPlayer extends LyricPlayerBase {
 
 	override resume(): void {
 		super.resume();
-		this.element.classList.add("playing");
+		this.element.classList.add(styles.playing);
 		this.interludeDots.resume();
 		for (const group of this.currentLyricGroups) {
 			group.mainLine.resume();

--- a/packages/core/src/lyric-player/dom/index.ts
+++ b/packages/core/src/lyric-player/dom/index.ts
@@ -157,6 +157,7 @@ export class DomLyricPlayer extends LyricPlayerBase {
 		this.setLinePosXSpringParams({});
 		this.setLinePosYSpringParams({});
 		this.setLineScaleSpringParams({});
+		this.setCurrentTime(initialTime, true);
 		this.calcLayout(true);
 		this.update(0);
 	}

--- a/packages/core/src/lyric-player/dom/lyric-group.ts
+++ b/packages/core/src/lyric-player/dom/lyric-group.ts
@@ -1,0 +1,132 @@
+import { LyricLineGroupBase } from "#lyric/base/group.ts";
+import styles from "#styles/lyric-player.module.css";
+import type { DomLyricPlayer } from "./index.ts";
+import type { LyricLineEl } from "./lyric-line.ts";
+
+export class LyricLineGroup extends LyricLineGroupBase<LyricLineEl> {
+	public element: HTMLElement;
+	public bgWrapper?: HTMLElement;
+	private lastIsActive?: boolean;
+
+	constructor(
+		public lyricPlayer: DomLyricPlayer,
+		mainLine: LyricLineEl,
+	) {
+		super(mainLine);
+		this.element = document.createElement("div");
+		this.element.className = styles.lyricLineWrapper;
+		this.element.appendChild(mainLine.getElement());
+
+		lyricPlayer.resizeObserver.observe(this.element);
+	}
+
+	get isInSight(): boolean {
+		const t = this.posY.getCurrentPosition();
+
+		let h = this.lyricPlayer.lyricGroupSize?.get(this)?.[1];
+		if (h === undefined || h === 0) {
+			h = this.element.clientHeight || 0;
+		}
+
+		const pb = this.lyricPlayer.size[1];
+		const ov = this.lyricPlayer.getOverscanPx();
+
+		return !(t > pb + h + ov || t < -h - ov);
+	}
+
+	show(): void {
+		if (!this.element.parentElement) {
+			this.lyricPlayer.getElement().appendChild(this.element);
+			this.lyricPlayer.resizeObserver.observe(this.element);
+		}
+
+		this.mainLine.show();
+		this.bgLine?.show();
+	}
+
+	hide(): void {
+		if (this.element.parentElement) {
+			this.lyricPlayer.resizeObserver.unobserve(this.element);
+			this.element.remove();
+		}
+	}
+
+	override update(delta: number): void {
+		if (this.isInSight) {
+			this.show();
+		} else {
+			this.hide();
+		}
+
+		super.update(delta);
+	}
+
+	addBgLine(bgLine: LyricLineEl): void {
+		this.bgLine = bgLine;
+
+		// 需要对比第一个词的开始时间而不是行起始时间，因为行的起始时间已经被
+		// `syncMainAndBackgroundLines` 同步过了
+		this.isBgFirst =
+			bgLine.getLine().words[0].startTime <
+			this.mainLine.getLine().words[0].startTime;
+
+		if (this.mainLine.getLine().isDuet) {
+			bgLine.getElement().classList.add(styles.lyricDuetLine);
+		}
+
+		this.bgWrapper = document.createElement("div");
+		this.bgWrapper.className = styles.bgWrapper;
+
+		this.bgWrapper.appendChild(bgLine.getElement());
+
+		if (this.isBgFirst) {
+			this.bgWrapper.classList.add(styles.bgWrapperTop);
+			this.element.insertBefore(this.bgWrapper, this.mainLine.getElement());
+			this.bgSlideY.setPosition(80);
+		} else {
+			this.element.appendChild(this.bgWrapper);
+		}
+	}
+
+	protected renderStyles(): void {
+		const y = this.posY.getCurrentPosition().toFixed(1);
+
+		this.element.style.transform = `translateY(${y}px)`;
+		this.element.style.opacity = this.opacity.toString();
+		this.element.style.filter = `blur(${Math.min(5, this.blur)}px)`;
+
+		if (!this.lyricPlayer.getEnableSpring()) {
+			this.element.style.transitionDelay = `${this.delay}ms`;
+		}
+
+		if (this.bgWrapper) {
+			if (this.lastIsActive !== this.isActive) {
+				this.lastIsActive = this.isActive;
+				this.bgWrapper.classList.toggle(styles.bgWrapperActive, this.isActive);
+			}
+
+			const slideY = this.bgSlideY.getCurrentPosition();
+			const slideYStr = slideY.toFixed(1);
+			const activeProgress = 1 - Math.abs(slideY) / 80;
+
+			const scaleStr = (0.8 + activeProgress * 0.2).toFixed(3);
+			this.bgWrapper.style.transform = `translateY(${slideYStr}%) scale(${scaleStr})`;
+
+			if (this.isBgFirst) {
+				const bgHeight = this.bgWrapper.clientHeight || 0;
+				const currentMarginTop = -bgHeight * (1 - activeProgress);
+				this.bgWrapper.style.marginTop = `${currentMarginTop.toFixed(1)}px`;
+			}
+
+			const targetHiddenYStr = this.isBgFirst ? "80.0" : "-80.0";
+			const isHidden = slideYStr === targetHiddenYStr && !this.isActive;
+			this.bgWrapper.classList.toggle(styles.bgWrapperHidden, isHidden);
+		}
+	}
+
+	override dispose(): void {
+		super.dispose();
+		this.lyricPlayer.resizeObserver.unobserve(this.element);
+		this.element.remove();
+	}
+}

--- a/packages/core/src/lyric-player/dom/lyric-group.ts
+++ b/packages/core/src/lyric-player/dom/lyric-group.ts
@@ -16,6 +16,7 @@ export class LyricLineGroup extends LyricLineGroupBase<LyricLineEl> {
 		this.element = document.createElement("div");
 		this.element.className = styles.lyricLineWrapper;
 		this.element.appendChild(mainLine.getElement());
+		this.posY.setPosition(window.innerHeight * 2);
 
 		lyricPlayer.resizeObserver.observe(this.element);
 	}

--- a/packages/core/src/lyric-player/dom/lyric-group.ts
+++ b/packages/core/src/lyric-player/dom/lyric-group.ts
@@ -1,5 +1,6 @@
 import { LyricLineGroupBase } from "#lyric/base/group.ts";
 import styles from "#styles/lyric-player.module.css";
+import { clamp01 } from "#utils/clamp.ts";
 import type { DomLyricPlayer } from "./index.ts";
 import type { LyricLineEl } from "./lyric-line.ts";
 
@@ -137,7 +138,7 @@ export class LyricLineGroup extends LyricLineGroupBase<LyricLineEl> {
 
 			const slideY = this.bgSlideY.getCurrentPosition();
 			const slideYStr = slideY.toFixed(1);
-			const activeProgress = 1 - Math.abs(slideY) / 80;
+			const activeProgress = clamp01(1 - Math.abs(slideY) / 80);
 
 			const scaleStr = (0.8 + activeProgress * 0.2).toFixed(3);
 			this.bgWrapper.style.transform = `translateY(${slideYStr}%) scale(${scaleStr})`;

--- a/packages/core/src/lyric-player/dom/lyric-group.ts
+++ b/packages/core/src/lyric-player/dom/lyric-group.ts
@@ -63,6 +63,13 @@ export class LyricLineGroup extends LyricLineGroupBase<LyricLineEl> {
 	}
 
 	addBgLine(bgLine: LyricLineEl): void {
+		if (this.bgLine) {
+			this.bgLine.dispose();
+		}
+		if (this.bgWrapper) {
+			this.bgWrapper.remove();
+		}
+
 		this.bgLine = bgLine;
 
 		// 需要对比第一个词的开始时间而不是行起始时间，因为行的起始时间已经被

--- a/packages/core/src/lyric-player/dom/lyric-group.ts
+++ b/packages/core/src/lyric-player/dom/lyric-group.ts
@@ -37,7 +37,22 @@ export class LyricLineGroup extends LyricLineGroupBase<LyricLineEl> {
 
 	show(): void {
 		if (!this.element.parentElement) {
-			this.lyricPlayer.getElement().appendChild(this.element);
+			const playerEl = this.lyricPlayer.getElement();
+			const groups = this.lyricPlayer.currentLyricGroups;
+			const myIndex = groups.indexOf(this);
+
+			let referenceNode: HTMLElement | null = null;
+			if (myIndex !== -1) {
+				for (let i = myIndex + 1; i < groups.length; i++) {
+					if (groups[i].element.parentElement === playerEl) {
+						referenceNode = groups[i].element;
+						break;
+					}
+				}
+			}
+
+			playerEl.insertBefore(this.element, referenceNode);
+
 			this.lyricPlayer.resizeObserver.observe(this.element);
 		}
 
@@ -49,6 +64,9 @@ export class LyricLineGroup extends LyricLineGroupBase<LyricLineEl> {
 		if (this.element.parentElement) {
 			this.lyricPlayer.resizeObserver.unobserve(this.element);
 			this.element.remove();
+
+			this.mainLine.teardownContent();
+			this.bgLine?.teardownContent();
 		}
 	}
 

--- a/packages/core/src/lyric-player/dom/lyric-group.ts
+++ b/packages/core/src/lyric-player/dom/lyric-group.ts
@@ -110,7 +110,11 @@ export class LyricLineGroup extends LyricLineGroupBase<LyricLineEl> {
 
 		this.bgWrapper.appendChild(bgLine.getElement());
 
-		if (this.isBgFirst) {
+		const alwaysPostposition =
+			this.lyricPlayer.getAlwaysPostpositionBackground();
+		const shouldBgFirst = !alwaysPostposition && this.isBgFirst;
+
+		if (shouldBgFirst) {
 			this.bgWrapper.classList.add(styles.bgWrapperTop);
 			this.element.insertBefore(this.bgWrapper, this.mainLine.getElement());
 			this.bgSlideY.setPosition(80);
@@ -143,13 +147,19 @@ export class LyricLineGroup extends LyricLineGroupBase<LyricLineEl> {
 			const scaleStr = (0.8 + activeProgress * 0.2).toFixed(3);
 			this.bgWrapper.style.transform = `translateY(${slideYStr}%) scale(${scaleStr})`;
 
-			if (this.isBgFirst) {
+			const alwaysPostposition =
+				this.lyricPlayer.getAlwaysPostpositionBackground();
+			const shouldBgFirst = !alwaysPostposition && this.isBgFirst;
+
+			if (shouldBgFirst) {
 				const bgHeight = this.bgWrapper.clientHeight || 0;
 				const currentMarginTop = -bgHeight * (1 - activeProgress);
 				this.bgWrapper.style.marginTop = `${currentMarginTop.toFixed(1)}px`;
+			} else {
+				this.bgWrapper.style.marginTop = "";
 			}
 
-			const targetHiddenYStr = this.isBgFirst ? "80.0" : "-80.0";
+			const targetHiddenYStr = shouldBgFirst ? "80.0" : "-80.0";
 			const isHidden = slideYStr === targetHiddenYStr && !this.isActive;
 			this.bgWrapper.classList.toggle(styles.bgWrapperHidden, isHidden);
 		}

--- a/packages/core/src/lyric-player/dom/lyric-group.ts
+++ b/packages/core/src/lyric-player/dom/lyric-group.ts
@@ -74,9 +74,13 @@ export class LyricLineGroup extends LyricLineGroupBase<LyricLineEl> {
 
 		// 需要对比第一个词的开始时间而不是行起始时间，因为行的起始时间已经被
 		// `syncMainAndBackgroundLines` 同步过了
-		this.isBgFirst =
-			bgLine.getLine().words[0].startTime <
-			this.mainLine.getLine().words[0].startTime;
+		const bgStartTime =
+			bgLine.getLine().words[0]?.startTime ?? bgLine.getLine().startTime;
+		const mainStartTime =
+			this.mainLine.getLine().words[0]?.startTime ??
+			this.mainLine.getLine().startTime;
+
+		this.isBgFirst = bgStartTime < mainStartTime;
 
 		if (this.mainLine.getLine().isDuet) {
 			bgLine.getElement().classList.add(styles.lyricDuetLine);

--- a/packages/core/src/lyric-player/dom/lyric-line.ts
+++ b/packages/core/src/lyric-player/dom/lyric-line.ts
@@ -1,14 +1,14 @@
 import bezier from "bezier-easing";
+import type { LyricLine, LyricWord } from "#interfaces";
 import { LyricLineRenderMode } from "#lyric/base/consts.ts";
 import { LyricLineBase } from "#lyric/base/line.ts";
-import type { LyricLine, LyricWord } from "#interfaces";
 import styles from "#styles/lyric-player.module.css";
+import { clamp, clamp01, clampPositive } from "#utils/clamp.ts";
 import { isCJK } from "#utils/is-cjk.ts";
 import { LineBalancer } from "#utils/line-balancer.ts";
 import { chunkAndSplitLyricWords } from "#utils/lyric-split-words.ts";
 import { createMatrix4, matrix4ToCSS, scaleMatrix4 } from "#utils/matrix.ts";
 import type { DomLyricPlayer } from ".";
-import { clamp, clamp01, clampPositive } from "#utils/clamp.ts";
 
 interface RealWord extends LyricWord {
 	mainElement: HTMLSpanElement;
@@ -108,7 +108,6 @@ export class LyricLineEl extends LyricLineBase {
 		},
 	) {
 		super();
-		this._prevParentEl = lyricPlayer.getElement();
 		lyricPlayer.resizeObserver.observe(this.element);
 		this.element.setAttribute("class", styles.lyricLine);
 		if (this.lyricLine.isBG) {
@@ -117,7 +116,6 @@ export class LyricLineEl extends LyricLineBase {
 		if (this.lyricLine.isDuet) {
 			this.element.classList.add(styles.lyricDuetLine);
 		}
-		this.lineTransforms.posY.setPosition(window.innerHeight * 2);
 		this.element.appendChild(document.createElement("div")); // 歌词行
 		this.element.appendChild(document.createElement("div")); // 翻译行
 		this.element.appendChild(document.createElement("div")); // 音译行
@@ -333,43 +331,23 @@ export class LyricLineEl extends LyricLineBase {
 		return this.lyricLine;
 	}
 	// private _hide = true;
-	private _prevParentEl: HTMLElement;
 	private lastStyle = "";
 	show(): void {
-		// this._hide = false;
-		if (!this.element.parentElement) {
-			this._prevParentEl.appendChild(this.element);
-			this.lyricPlayer.resizeObserver.observe(this.element);
-		}
 		if (!this.built) {
 			this.rebuildElement();
 			this.built = true;
 			this.updateMaskImageSync();
 		}
-		this.rebuildStyle();
 	}
-	hide(): void {
-		// this._hide = true;
-		if (this.element.parentElement) {
-			this._prevParentEl.removeChild(this.element);
-			this.lyricPlayer.resizeObserver.unobserve(this.element);
-		}
-		if (this.built) {
-			this.disposeElements();
-			this.built = false;
-		}
-	}
+
 	private rebuildStyle() {
 		let style = "";
-		// if (this.lyricPlayer.getEnableSpring()) {
-		style += `transform:translateY(${this.lineTransforms.posY
-			.getCurrentPosition()
-			.toFixed(
-				1,
-			)}px) scale(${(this.lineTransforms.scale.getCurrentPosition() / 100).toFixed(4)});`;
-		if (!this.lyricPlayer.getEnableSpring() && this.isInSight) {
+		style += `transform: scale(${(this.lineTransforms.scale.getCurrentPosition() / 100).toFixed(4)});`;
+
+		if (!this.lyricPlayer.getEnableSpring()) {
 			style += `transition-delay:${this.delay}ms;`;
 		}
+
 		style += `filter:blur(${Math.min(5, this.blur)}px);`;
 		if (style !== this.lastStyle) {
 			this.lastStyle = style;
@@ -1057,7 +1035,6 @@ export class LyricLineEl extends LyricLineBase {
 	}
 
 	override setTransform(
-		top: number = this.top,
 		scale: number = this.scale,
 		opacity = 1,
 		blur = 0,
@@ -1065,38 +1042,24 @@ export class LyricLineEl extends LyricLineBase {
 		delay = 0,
 		mode: LyricLineRenderMode = LyricLineRenderMode.SOLID,
 	): void {
-		super.setTransform(top, scale, opacity, blur, force, delay);
+		super.setTransform(scale, opacity, blur, force, delay);
+
 		this.renderMode = mode;
-		const beforeInSight = this.isInSight;
 		const enableSpring = this.lyricPlayer.getEnableSpring();
-		this.top = top;
+
+		this.top = 0;
 		this.scale = scale;
 		this.delay = (delay * 1000) | 0;
+
 		const main = this.element.children[0] as HTMLDivElement;
-		// main.style.opacity = `${opacity *
-		// 	(!this.hasFaded ? 1 : this.lyricPlayer._getIsNonDynamic() ? 1 : 0.3)
-		// 	}`;
 		main.style.opacity = `${opacity}`;
+
 		if (force || !enableSpring) {
 			this.blur = Math.min(32, blur);
-			// if (force) this.element.classList.add(styles.tmpDisableTransition);
-			// this.lineWebAnimationTransforms.posX.setTargetPosition(left);
-			// this.lineWebAnimationTransforms.posY.setTargetPosition(top);
-			// this.lineWebAnimationTransforms.scale.setTargetPosition(scale);
-			this.lineTransforms.posY.setPosition(top);
 			this.lineTransforms.scale.setPosition(scale);
-			if (!enableSpring) {
-				const afterInSight = this.isInSight;
-				if (beforeInSight || afterInSight) {
-					this.show();
-				} else {
-					this.hide();
-				}
-			} else this.rebuildStyle();
-			// if (force)
-			// 	requestAnimationFrame(() => {
-			// 		this.element.classList.remove(styles.tmpDisableTransition);
-			// 	});
+
+			this.rebuildStyle();
+
 			const currentScale = this.lineTransforms.scale.getCurrentPosition();
 			this.updateMaskAlphaTargets(currentScale / 100);
 			this.currentBrightAlpha = this.targetBrightAlpha;
@@ -1110,15 +1073,10 @@ export class LyricLineEl extends LyricLineBase {
 				String(this.currentDarkAlpha),
 			);
 		} else {
-			// this.lineWebAnimationTransforms.posX.stop();
-			// this.lineWebAnimationTransforms.posY.stop();
-			// this.lineWebAnimationTransforms.scale.stop();
-			this.lineTransforms.posY.setTargetPosition(top, delay);
 			this.lineTransforms.scale.setTargetPosition(scale);
 			if (this.blur !== Math.min(5, blur)) {
 				this.blur = Math.min(5, blur);
-				const roundedBlur = blur.toFixed(3);
-				this.element.style.filter = `blur(${roundedBlur}px)`;
+				this.element.style.filter = `blur(${blur.toFixed(3)}px)`;
 			}
 		}
 	}
@@ -1126,14 +1084,10 @@ export class LyricLineEl extends LyricLineBase {
 	update(delta = 0): void {
 		if (!this.lyricPlayer.getEnableSpring()) return;
 
-		this.lineTransforms.posY.update(delta);
 		this.lineTransforms.scale.update(delta);
+		this.rebuildStyle();
 
-		if (this.isInSight) {
-			this.show();
-		} else {
-			this.hide();
-		}
+		if (!this.built) return;
 
 		const currentScale = this.lineTransforms.scale.getCurrentPosition() / 100;
 		this.updateMaskAlphaTargets(currentScale);
@@ -1144,14 +1098,6 @@ export class LyricLineEl extends LyricLineBase {
 		return `[位移: ${this.top}; 缩放: ${this.scale}; 延时: ${this.delay}]`;
 	}
 
-	get isInSight(): boolean {
-		const t = this.lineTransforms.posY.getCurrentPosition();
-		const h = this.lyricPlayer.lyricLinesSize.get(this)?.[1] ?? 0;
-		const b = t + h;
-		const pb = this.lyricPlayer.size[1];
-		const ov = this.lyricPlayer.getOverscanPx();
-		return !(t > pb + h + ov || b < -h - ov);
-	}
 	private disposeElements() {
 		this.balancer?.reset();
 		for (const realWord of this.splittedWords) {

--- a/packages/core/src/lyric-player/dom/lyric-line.ts
+++ b/packages/core/src/lyric-player/dom/lyric-line.ts
@@ -1098,6 +1098,13 @@ export class LyricLineEl extends LyricLineBase {
 		return `[位移: ${this.top}; 缩放: ${this.scale}; 延时: ${this.delay}]`;
 	}
 
+	teardownContent(): void {
+		if (this.built) {
+			this.disposeElements();
+			this.built = false;
+		}
+	}
+
 	private disposeElements() {
 		this.balancer?.reset();
 		for (const realWord of this.splittedWords) {

--- a/packages/core/src/lyric-player/dom/lyric-line.ts
+++ b/packages/core/src/lyric-player/dom/lyric-line.ts
@@ -108,7 +108,6 @@ export class LyricLineEl extends LyricLineBase {
 		},
 	) {
 		super();
-		lyricPlayer.resizeObserver.observe(this.element);
 		this.element.setAttribute("class", styles.lyricLine);
 		if (this.lyricLine.isBG) {
 			this.element.classList.add(styles.lyricBgLine);

--- a/packages/core/src/styles/lyric-player.module.css
+++ b/packages/core/src/styles/lyric-player.module.css
@@ -287,4 +287,11 @@
 			}
 		}
 	}
+
+	&:not(.playing) .bgWrapper {
+		position: relative;
+		top: auto;
+		bottom: auto;
+		opacity: 1;
+	}
 }

--- a/packages/core/src/styles/lyric-player.module.css
+++ b/packages/core/src/styles/lyric-player.module.css
@@ -1,48 +1,38 @@
 .lyricLineWrapper {
 	position: absolute;
-	left: 0;
 	top: 0;
-	width: 100%;
+	left: 0;
 	display: flex;
 	flex-direction: column;
 	align-items: flex-start;
+	width: 100%;
 
 	will-change: transform, opacity, filter;
-
 	transition:
 		opacity 0.4s ease,
 		filter 0.4s ease;
 }
 
-:global(.amll-lyric-player).hasDuetLine .lyricLineWrapper:has(.lyricDuetLine) {
-	align-items: flex-end;
-}
-
-:global(.amll-lyric-player).hasDuetLine
-	.lyricLineWrapper:has(.lyricDuetLine)
-	.bgWrapper {
-	transform-origin: calc(100% - var(--lyric-line-padding-x)) top;
-}
-
 .lyricLine {
 	position: relative;
-	backface-visibility: hidden;
-	transform-origin: left;
+	box-sizing: border-box;
 	width: var(--amll-lp-width, 100%);
 	min-width: var(--amll-lp-width, 100%);
 	max-width: var(--amll-lp-width, 100%);
 	height: fit-content;
 	padding: 0.5em 1em;
+	padding-left: 1em;
+	padding-right: 1em;
+	border-radius: 0.25em;
+
 	contain: content;
+	backface-visibility: hidden;
+	transform-origin: left;
 	will-change: transform;
+
 	transition:
 		background-color 0.25s,
 		box-shadow 0.25s;
-	box-sizing: border-box;
-	border-radius: 0.25em;
-
-	padding-left: 1em;
-	padding-right: 1em;
 
 	@media screen and (max-width: 500px) {
 		padding-left: 20px;
@@ -69,9 +59,9 @@
 }
 
 .lyricMainLine {
-	transition: opacity 0.3s 0.1s;
 	margin: -1em;
 	padding: 1em;
+	transition: opacity 0.3s 0.1s;
 
 	& span {
 		display: inline-block;
@@ -80,18 +70,18 @@
 	}
 
 	.romanWord {
-		font-size: 0.5em;
-		line-height: 1em;
 		display: flex;
 		padding-inline-end: 0.3em;
+		font-size: 0.5em;
+		line-height: 1em;
 	}
 
 	.rubyWord {
-		font-size: 0.5em;
-		line-height: 1em;
 		display: flex;
 		justify-content: center;
 		min-height: 1em;
+		font-size: 0.5em;
+		line-height: 1em;
 	}
 
 	.wordWithRuby {
@@ -109,22 +99,22 @@
 
 	& > span,
 	span.emphasizeWrapper {
-		white-space: pre-wrap;
 		display: inline-block;
-		padding: 1em;
 		margin: -1em;
-		will-change: transform;
+		padding: 1em;
+		white-space: pre-wrap;
 		vertical-align: bottom;
+		will-change: transform;
 
 		&.emphasize,
 		span.emphasize {
-			padding: 1em;
 			margin: -1em;
+			padding: 1em;
 			backface-visibility: hidden;
 
 			& > span {
-				padding: 1em;
 				margin: -1em;
+				padding: 1em;
 				will-change: transform;
 				backface-visibility: hidden;
 			}
@@ -134,45 +124,80 @@
 
 .lyricBgLine {
 	opacity: 0.4;
+	/* 因为字体大小缩小了，故内边距要和主行字体大小统一，行边距计算公式为 100% / font-size 转 em 单位 */
+	padding: 1vh
+		calc(var(--amll-lp-line-padding-x, 1em) / var(--amll-lp-bg-line-scale, 0.7));
 	font-size: max(calc(1em * var(--amll-lp-bg-line-scale, 0.7)), 10px);
 	transition:
 		background-color 0.25s,
 		box-shadow 0.25s;
-	/* 因为字体大小缩小了，故内边距要和主行字体大小统一，行边距计算公式为 100% / font-size 转 em 单位 */
-	padding: 1vh
-		calc(var(--amll-lp-line-padding-x, 1em) / var(--amll-lp-bg-line-scale, 0.7));
 
 	.lyricMainLine {
 		padding: 1.2em 1em;
 	}
 
 	&.active {
+		opacity: 0.4;
 		transition:
 			background-color 0.25s,
 			box-shadow 0.25s;
-		opacity: 0.4;
+	}
+}
+
+.lyricSubLine {
+	opacity: 0.3;
+	font-size: max(0.5em, 10px);
+	line-height: 1.5em;
+	transition: opacity 0.2s 0.25s;
+
+	@supports (mix-blend-mode: plus-lighter) {
+		opacity: 0.3;
+	}
+}
+
+.bottomLine {
+	padding-top: 0;
+	padding-bottom: 0;
+	line-height: 1.8em;
+	cursor: default;
+
+	&:empty {
+		display: none;
+		height: 0;
+		margin: 0;
+		padding: 0;
 	}
 }
 
 .bgWrapper {
-	width: 100%;
-	display: flex;
-	flex-direction: column;
-	align-items: inherit;
-	z-index: -1;
 	position: absolute;
 	top: 100%;
 	left: 0;
-	transform-origin: var(--lyric-line-padding-x) top;
+	z-index: -1;
+	display: flex;
+	flex-direction: column;
+	align-items: inherit;
+	width: 100%;
+
 	visibility: visible;
 	pointer-events: auto;
 	opacity: 0;
+	transform-origin: var(--lyric-line-padding-x) top;
 	transition: opacity 0.3s ease;
+}
+
+.bgWrapperTop {
+	position: relative;
+	top: auto;
+	bottom: auto;
+	margin-top: -999px;
+	transform-origin: var(--lyric-line-padding-x) bottom;
 }
 
 .bgWrapperActive {
 	position: relative;
 	top: auto;
+	bottom: auto;
 	opacity: 1;
 }
 
@@ -181,55 +206,37 @@
 	pointer-events: none;
 }
 
-.bgWrapperTop {
-	position: relative;
-	top: auto;
-	bottom: auto;
-	transform-origin: var(--lyric-line-padding-x) bottom;
+.interludeDots {
+	position: absolute;
+	left: 0;
+	display: flex;
+	gap: 0.25em;
+	width: fit-content;
+	height: clamp(0.5em, 1vh, 3em);
+	padding: 2.5% 0.75em;
 
-	margin-top: -999px;
-}
+	opacity: 0;
+	transform-origin: center;
+	transition: opacity 0.25s;
 
-.bgWrapperActive {
-	position: relative;
-	top: auto;
-	bottom: auto;
-	opacity: 1;
-}
-
-:global(.amll-lyric-player) {
-	&:hover .lyricLine,
-	&:hover .lyricLineWrapper {
-		/* biome-ignore lint/complexity/noImportantStyles: 覆盖内联样式 */
-		filter: unset !important;
+	&.enabled {
+		opacity: 1;
 	}
 
-	--lyric-line-padding-x: 1em;
-
-	@media screen and (max-width: 500px) {
-		--lyric-line-padding-x: 20px;
+	& > * {
+		display: inline-block;
+		width: clamp(0.5em, 1vh, 3em);
+		height: clamp(0.5em, 1vh, 3em);
+		margin-right: 4px;
+		border-radius: 50%;
+		background-color: var(--amll-lp-color, white);
+		aspect-ratio: 1 / 1;
 	}
 
-	&.hasDuetLine {
-		.lyricLine:not(.lyricDuetLine) {
-			padding-right: 15%;
-		}
-
-		.lyricDuetLine {
-			padding-left: 15%;
-		}
+	&.duet {
+		right: 0;
+		transform-origin: center;
 	}
-
-	&:not(:global(.playing)) > .lyricBgLine {
-		opacity: 0.4;
-	}
-}
-
-.lyricSubLine {
-	font-size: max(0.5em, 10px);
-	line-height: 1.5em;
-	transition: opacity 0.2s 0.25s;
-	opacity: 0.3;
 }
 
 .disableSpring > * {
@@ -240,59 +247,43 @@
 		box-shadow 0.25s;
 }
 
-.interludeDots {
-	height: clamp(0.5em, 1vh, 3em);
-	transition: opacity 0.25s;
-	transform-origin: center;
-	width: fit-content;
-	padding: 2.5% 0.75em;
-	position: absolute;
-	display: flex;
-	gap: 0.25em;
-	left: 0;
-	opacity: 0;
-
-	&.enabled {
-		opacity: 1;
-	}
-
-	& > * {
-		width: clamp(0.5em, 1vh, 3em);
-		height: clamp(0.5em, 1vh, 3em);
-		display: inline-block;
-		border-radius: 50%;
-		aspect-ratio: 1 / 1;
-		background-color: var(--amll-lp-color, white);
-		margin-right: 4px;
-	}
-
-	&.duet {
-		right: 0;
-		transform-origin: center;
-	}
-}
-
-@supports (mix-blend-mode: plus-lighter) {
-	.lyricSubLine {
-		opacity: 0.3;
-	}
-}
-
 .tmpDisableTransition {
 	/* biome-ignore lint/complexity/noImportantStyles: 覆盖内联样式 */
 	transition: none !important;
 }
 
-.bottomLine {
-	padding-top: 0;
-	padding-bottom: 0;
-	cursor: default;
-	line-height: 1.8em;
-}
+:global(.amll-lyric-player) {
+	--lyric-line-padding-x: 1em;
 
-.bottomLine:empty {
-	display: none;
-	padding: 0;
-	margin: 0;
-	height: 0;
+	@media screen and (max-width: 500px) {
+		--lyric-line-padding-x: 20px;
+	}
+
+	&:hover .lyricLine,
+	&:hover .lyricLineWrapper {
+		/* biome-ignore lint/complexity/noImportantStyles: 覆盖内联样式 */
+		filter: unset !important;
+	}
+
+	&.hasDuetLine {
+		.lyricLine:not(.lyricDuetLine) {
+			padding-right: 15%;
+		}
+
+		.lyricDuetLine {
+			padding-left: 15%;
+		}
+
+		.lyricLineWrapper:has(.lyricDuetLine) {
+			align-items: flex-end;
+
+			.bgWrapper {
+				transform-origin: calc(100% - var(--lyric-line-padding-x)) top;
+			}
+
+			.bgWrapperTop {
+				transform-origin: calc(100% - var(--lyric-line-padding-x)) bottom;
+			}
+		}
+	}
 }

--- a/packages/core/src/styles/lyric-player.module.css
+++ b/packages/core/src/styles/lyric-player.module.css
@@ -1,19 +1,41 @@
-/* 给每行歌词应用的样式 */
-.lyricLine {
+.lyricLineWrapper {
 	position: absolute;
+	left: 0;
+	top: 0;
+	width: 100%;
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+
+	will-change: transform, opacity, filter;
+
+	transition:
+		opacity 0.4s ease,
+		filter 0.4s ease;
+}
+
+:global(.amll-lyric-player).hasDuetLine .lyricLineWrapper:has(.lyricDuetLine) {
+	align-items: flex-end;
+}
+
+:global(.amll-lyric-player).hasDuetLine
+	.lyricLineWrapper:has(.lyricDuetLine)
+	.bgWrapper {
+	transform-origin: calc(100% - var(--lyric-line-padding-x)) top;
+}
+
+.lyricLine {
+	position: relative;
 	backface-visibility: hidden;
 	transform-origin: left;
 	width: var(--amll-lp-width, 100%);
 	min-width: var(--amll-lp-width, 100%);
 	max-width: var(--amll-lp-width, 100%);
-	width: 100%;
 	height: fit-content;
 	padding: 0.5em 1em;
 	contain: content;
 	will-change: transform;
 	transition:
-		opacity 0.25s,
-		filter 0.2s,
 		background-color 0.25s,
 		box-shadow 0.25s;
 	box-sizing: border-box;
@@ -34,60 +56,10 @@
 
 	&:has(> *):hover {
 		background-color: var(--amll-lp-hover-bg-color, #fff1);
-		/* box-shadow: 0 0 0 4px var(--amll-lp-hover-bg-color, #fff1); */
 	}
 
 	&:has(> *):active {
 		background-color: var(--amll-lp-hover-bg-color, #ffffff05);
-		/* box-shadow: 0 0 0 var(--amll-lp-hover-bg-color, #fff1); */
-	}
-}
-
-.lyricBgLine {
-	opacity: 0.0001;
-	font-size: max(calc(1em * var(--amll-lp-bg-line-scale, 0.7)), 10px);
-	transition:
-		opacity 0.25s,
-		scale 0.5s,
-		filter 0.2s,
-		background-color 0.25s,
-		box-shadow 0.25s;
-	/* 因为字体大小缩小了，故内边距要和主行字体大小统一，行边距计算公式为 100% / font-size 转 em 单位 */
-	padding: 1vh
-		calc(var(--amll-lp-line-padding-x, 1em) / var(--amll-lp-bg-line-scale, 0.7));
-
-	.lyricMainLine {
-		padding: 1.2em 1em;
-	}
-
-	&.active {
-		transition:
-			opacity 0.5s 0.25s,
-			scale 1.5s cubic-bezier(0, 1, 0, 1) 0.25s,
-			filter 0.2s,
-			background-color 0.25s,
-			box-shadow 0.25s;
-		opacity: 0.4;
-	}
-}
-
-:global(.amll-lyric-player) {
-	&:hover .lyricLine {
-		filter: unset !important;
-	}
-
-	&.hasDuetLine {
-		.lyricLine:not(.lyricDuetLine) {
-			padding-right: 15%;
-		}
-
-		.lyricDuetLine {
-			padding-left: 15%;
-		}
-	}
-
-	&:not(:global(.playing)) > .lyricBgLine {
-		opacity: 0.4;
 	}
 }
 
@@ -160,6 +132,99 @@
 	}
 }
 
+.lyricBgLine {
+	opacity: 0.4;
+	font-size: max(calc(1em * var(--amll-lp-bg-line-scale, 0.7)), 10px);
+	transition:
+		background-color 0.25s,
+		box-shadow 0.25s;
+	/* 因为字体大小缩小了，故内边距要和主行字体大小统一，行边距计算公式为 100% / font-size 转 em 单位 */
+	padding: 1vh
+		calc(var(--amll-lp-line-padding-x, 1em) / var(--amll-lp-bg-line-scale, 0.7));
+
+	.lyricMainLine {
+		padding: 1.2em 1em;
+	}
+
+	&.active {
+		transition:
+			background-color 0.25s,
+			box-shadow 0.25s;
+		opacity: 0.4;
+	}
+}
+
+.bgWrapper {
+	width: 100%;
+	display: flex;
+	flex-direction: column;
+	align-items: inherit;
+	z-index: -1;
+	position: absolute;
+	top: 100%;
+	left: 0;
+	transform-origin: var(--lyric-line-padding-x) top;
+	visibility: visible;
+	pointer-events: auto;
+	opacity: 0;
+	transition: opacity 0.3s ease;
+}
+
+.bgWrapperActive {
+	position: relative;
+	top: auto;
+	opacity: 1;
+}
+
+.bgWrapperHidden {
+	visibility: hidden;
+	pointer-events: none;
+}
+
+.bgWrapperTop {
+	position: relative;
+	top: auto;
+	bottom: auto;
+	transform-origin: var(--lyric-line-padding-x) bottom;
+
+	margin-top: -999px;
+}
+
+.bgWrapperActive {
+	position: relative;
+	top: auto;
+	bottom: auto;
+	opacity: 1;
+}
+
+:global(.amll-lyric-player) {
+	&:hover .lyricLine,
+	&:hover .lyricLineWrapper {
+		/* biome-ignore lint/complexity/noImportantStyles: 覆盖内联样式 */
+		filter: unset !important;
+	}
+
+	--lyric-line-padding-x: 1em;
+
+	@media screen and (max-width: 500px) {
+		--lyric-line-padding-x: 20px;
+	}
+
+	&.hasDuetLine {
+		.lyricLine:not(.lyricDuetLine) {
+			padding-right: 15%;
+		}
+
+		.lyricDuetLine {
+			padding-left: 15%;
+		}
+	}
+
+	&:not(:global(.playing)) > .lyricBgLine {
+		opacity: 0.4;
+	}
+}
+
 .lyricSubLine {
 	font-size: max(0.5em, 10px);
 	line-height: 1.5em;
@@ -214,6 +279,7 @@
 }
 
 .tmpDisableTransition {
+	/* biome-ignore lint/complexity/noImportantStyles: 覆盖内联样式 */
 	transition: none !important;
 }
 

--- a/packages/core/src/styles/lyric-player.module.css
+++ b/packages/core/src/styles/lyric-player.module.css
@@ -239,7 +239,8 @@
 	}
 }
 
-.disableSpring > * {
+.disableSpring > *,
+.disableSpring .lyricLine {
 	transition:
 		filter 0.25s,
 		transform 0.5s,


### PR DESCRIPTION
## 摘要

引入了「歌词组」概念（`LyricLineGroupBase` 类）来统一封装主歌词和背景人声。

考虑到目前的 `LyricLineEl` 结构上已经写死只能有一行歌词，直接在其内部强行塞入背景人声会非常难以实现。因此在外部嵌套了一层 `LyricLineGroupBase`，这同时也简化了之前播放器散落在各处布局时对背景人声的计算。现在播放器核心只需直接对 `LyricLineGroupBase` 进行操作，主次歌词之间的相对排版（包含位置、时序配合等）则全部交由歌词组内部自行消化。

得益于架构上的改进，同时也顺便实现了「前置背景人声」功能。

**滚动对齐逻辑调整：**
现在的滚动目标会对齐到整个“歌词组”，这意味着当存在背景歌词时，视口会对齐在主歌词与背景人声之间的空隙处，而不是对齐到主歌词行。不过这看起来应该更符合 Apple Music 的样式了。

**已知问题：**
当背景人声行展开并引发高度变化时，会触发 `resizeObserver` 并调用 `calcLayout(true)`，导致各歌词行的弹簧 `delay` 归零，并失去错落有致的滚动效果。但是在展开背景人声歌词行时进行错落有致地滚动看起来不是很好，我暂时想不到有什么更好的方法解决这两者的关系，所以先保持这样不变了，之后再视情况进一步优化。

## 改动点

* 引入 `LyricLineGroupBase` 基类，将播放器基类的排版操作粒度从“单行歌词”提升至“歌词组”。
* 为 DOM 播放器派生实现了 `LyricLineGroup` 类，完整处理了主/背景歌词的节点挂载、前置背景人声的样式适配以及相关的组内动画逻辑。

## TODOs

* 将原先绑定在单行歌词上的交互样式（Hover 效果、点击判定等）上移至歌词组级别。
* 进一步优化歌词组内主次歌词之间的间距与排版细节。

## 验证

<img width="200" height="200" alt="works on my machine" src="https://github.com/user-attachments/assets/30de0668-9415-4d12-8ec8-7a3d36830c07" />