### PR TITLE
fix: 更正 stringifyLrcA2 函数大小写错误

### DIFF
--- a/.nx/version-plans/version-plan-1779033766318.md
+++ b/.nx/version-plans/version-plan-1779033766318.md
@@ -1,0 +1,7 @@
+---
+"@applemusic-like-lyrics/lyric": patch
+---
+
+fix: 更正 stringifyLrcA2 函数大小写错误
+
+将 `stringifylrcA2` 更正为 `stringifyLrcA2`。我们保留了兼容旧版本拼写的接口，但其将在未来版本中移除。

--- a/packages/lyric/src/formats/lrca2.ts
+++ b/packages/lyric/src/formats/lrca2.ts
@@ -89,7 +89,7 @@ export function parseLrcA2(lrc: string): LyricLine[] {
  * @param lines 歌词数组
  * @returns LRC A2 格式的字符串
  */
-export function stringifylrcA2(lines: LyricLine[]): string {
+export function stringifyLrcA2(lines: LyricLine[]): string {
 	return lines
 		.map((line) => {
 			const normalizedLineStartTime = normalizeTimestamp(line.startTime);

--- a/packages/lyric/src/index.ts
+++ b/packages/lyric/src/index.ts
@@ -3,11 +3,24 @@ export { decryptQrcHex, encryptQrcHex } from "./formats/eqrc";
 export { parseEslrc, stringifyEslrc } from "./formats/eslrc";
 export { parseLqe, stringifyLqe } from "./formats/lqe";
 export { parseLrc, stringifyLrc } from "./formats/lrc";
-export { parseLrcA2, stringifylrcA2 } from "./formats/lrca2";
+export { parseLrcA2, stringifyLrcA2 } from "./formats/lrca2";
 export { parseLyl, stringifyLyl } from "./formats/lyl";
 export { parseLys, stringifyLys } from "./formats/lys";
 export { parseQrc, stringifyQrc } from "./formats/qrc";
 export { parseTTML, stringifyTTML } from "./formats/ttml";
 export { parseYrc, stringifyYrc } from "./formats/yrc";
+
+import { stringifyLrcA2 } from "./formats/lrca2";
+
+/**
+ * {@link stringifyLrcA2} 的别名。
+ *
+ * @deprecated 此为兼容旧版本拼写错误的接口，请改用 `stringifyLrcA2`。此接口将在未来版本中移除。
+ */
+export function stringifylrcA2(
+	...args: Parameters<typeof stringifyLrcA2>
+): ReturnType<typeof stringifyLrcA2> {
+	return stringifyLrcA2(...args);
+}
 
 export type { LyricLine, LyricWord, TTMLLyric } from "./types";

--- a/packages/lyric/test/lrca2.test.ts
+++ b/packages/lyric/test/lrca2.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { parseLrcA2, stringifylrcA2 } from "../src/formats/lrca2";
+import { parseLrcA2, stringifyLrcA2 } from "../src/formats/lrca2";
 import { timeStampsTestCases } from "./timestampcase.fixture";
 
 describe("lrca2", () => {
@@ -68,7 +68,7 @@ describe("lrca2", () => {
 	});
 
 	it("stringifies words and preserves spaces", () => {
-		const result = stringifylrcA2([
+		const result = stringifyLrcA2([
 			{
 				startTime: 1000,
 				endTime: 3000,
@@ -90,7 +90,7 @@ describe("lrca2", () => {
 	});
 
 	it("stringifies empty-word line as bare line timestamp", () => {
-		const result = stringifylrcA2([
+		const result = stringifyLrcA2([
 			{
 				startTime: 1000,
 				endTime: 1000,
@@ -106,7 +106,7 @@ describe("lrca2", () => {
 	});
 
 	it("normalizes invalid timestamps when stringifying", () => {
-		const result = stringifylrcA2([
+		const result = stringifyLrcA2([
 			{
 				startTime: Number.NaN,
 				endTime: 0,
@@ -132,7 +132,7 @@ describe("lrca2", () => {
 		const input =
 			"[00:01.000]<00:01.000>Hello <00:01.500>World<00:02.000>\n[00:03.000]<00:03.000>Again<00:03.500>";
 		const first = parseLrcA2(input);
-		const text = stringifylrcA2(first);
+		const text = stringifyLrcA2(first);
 		const second = parseLrcA2(text);
 
 		expect(second).toEqual(first);
@@ -140,7 +140,7 @@ describe("lrca2", () => {
 
 	it("keeps exactly one space between adjacent words in '<time> word <time> word' pattern", () => {
 		const input = "[00:01.000]<00:01.000> word <00:01.500> word<00:02.000>";
-		const output = stringifylrcA2(parseLrcA2(input));
+		const output = stringifyLrcA2(parseLrcA2(input));
 
 		expect(output).toBe(
 			"[00:01.000]<00:01.000>word <00:01.500>word<00:02.000>",


### PR DESCRIPTION
将 `stringifylrcA2` 更正为 `stringifyLrcA2`，并暂时保留兼容旧版本拼写的接口