### PR TITLE
chore: 修正多余发布计划目标

### DIFF
--- a/.nx/version-plans/version-plan-1779170952912.md
+++ b/.nx/version-plans/version-plan-1779170952912.md
@@ -1,6 +1,5 @@
 ---
 core-bundle: patch
-'@applemusic-like-lyrics/lyric': patch
 ---
 
 chore(core): 一些简单的代码优化避免样式重新计算


### PR DESCRIPTION
#540 提供的发布计划错误地纳入了 `@applemusic-like-lyrics/lyric`，予以删除