### PR TITLE
chore(core): 简单优化一点Mesh着色器的代码

### DIFF
--- a/.nx/version-plans/version-plan-1783611897750.md
+++ b/.nx/version-plans/version-plan-1783611897750.md
@@ -1,0 +1,5 @@
+---
+core-bundle: patch
+---
+
+chore(core): 简单优化一点Mesh着色器的代码

--- a/packages/core/src/bg-render/mesh-renderer/index.ts
+++ b/packages/core/src/bg-render/mesh-renderer/index.ts
@@ -995,7 +995,7 @@ export class MeshGradientRenderer extends BaseRenderer {
 
 			this.mainProgram.use();
 			gl.activeTexture(gl.TEXTURE0);
-			this.mainProgram.setUniform1f("u_time", tickTime / 10000);
+			const uTime = tickTime / 10000;
 			this.mainProgram.setUniform1f(
 				"u_aspect",
 				this.manualControl ? 1 : this.canvas.width / this.canvas.height,
@@ -1003,6 +1003,9 @@ export class MeshGradientRenderer extends BaseRenderer {
 			this.mainProgram.setUniform1i("u_texture", 0);
 			this.mainProgram.setUniform1f("u_volume", this.volume);
 			this.mainProgram.setUniform1f("u_alpha", 1.0);
+			const angle = (uTime + this.volume) * 2.0;
+			this.mainProgram.setUniform1f("u_sinAngle", Math.sin(angle));
+			this.mainProgram.setUniform1f("u_cosAngle", Math.cos(angle));
 
 			state.texture.bind();
 			state.mesh.bind();

--- a/packages/core/src/bg-render/mesh-renderer/mesh.frag.glsl
+++ b/packages/core/src/bg-render/mesh-renderer/mesh.frag.glsl
@@ -1,11 +1,12 @@
-precision highp float;
+precision mediump float;
 
 varying vec3 v_color;
 varying vec2 v_uv;
 uniform sampler2D u_texture;
-uniform float u_time;
 uniform float u_volume;
 uniform float u_alpha;
+uniform float u_sinAngle;
+uniform float u_cosAngle;
 
 // 预计算常量
 const float INV_255 = 1.0 / 255.0;
@@ -13,27 +14,22 @@ const float HALF_INV_255 = 0.5 / 255.0;
 const float GRADIENT_NOISE_A = 52.9829189;
 const vec2 GRADIENT_NOISE_B = vec2(0.06711056, 0.00583715);
 
-/* Gradient noise from Jorge Jimenez's presentation: */
-/* http://www.iryoku.com/next-generation-post-processing-in-call-of-duty-advanced-warfare */
 float gradientNoise(in vec2 uv) {
     return fract(GRADIENT_NOISE_A * fract(dot(uv, GRADIENT_NOISE_B)));
 }
 
-// 优化的旋转函数，避免重复计算sin/cos
-vec2 rot(vec2 v, float angle) {
-    float s = sin(angle);
-    float c = cos(angle);
-    return vec2(c * v.x - s * v.y, s * v.x + c * v.y);
-}
-
 void main() {
-    // 合并计算以减少指令数
     float volumeEffect = u_volume * 2.0;
-    float timeVolume = u_time + u_volume;
-    
+
     float dither = INV_255 * gradientNoise(gl_FragCoord.xy) - HALF_INV_255;
+
     vec2 centeredUV = v_uv - vec2(0.2);
-    vec2 rotatedUV = rot(centeredUV, timeVolume * 2.0);
+
+    vec2 rotatedUV = vec2(
+        u_cosAngle * centeredUV.x - u_sinAngle * centeredUV.y,
+        u_sinAngle * centeredUV.x + u_cosAngle * centeredUV.y
+    );
+
     vec2 finalUV = rotatedUV * max(0.001, 1.0 - volumeEffect) + vec2(0.5);
     
     vec4 result = texture2D(u_texture, finalUV);

--- a/packages/core/src/bg-render/mesh-renderer/mesh.vert.glsl
+++ b/packages/core/src/bg-render/mesh-renderer/mesh.vert.glsl
@@ -1,4 +1,4 @@
-precision highp float;
+precision mediump float;
 
 attribute vec2 a_pos;
 attribute vec3 a_color;


### PR DESCRIPTION
稍微对着色器算法做了一点优化，不知道能不能对背景的绘制带来点可能的性能提升
- 将浮点精度降低到 mediump （可能改善移动端设备的性能？）
- 将每次都在着色器中计算的sin/cos的数值结果改成用uniform导入，以减少三角函数在GPU侧的计算量
- 其他零碎小优化