### PR TITLE
fix(react-full): 只为远程资源设置 crossOrigin 属性

### DIFF
--- a/.nx/version-plans/version-plan-1783882109978.md
+++ b/.nx/version-plans/version-plan-1783882109978.md
@@ -1,0 +1,5 @@
+---
+'@applemusic-like-lyrics/react-full': patch
+---
+
+fix(react-full): 只为远程资源设置 crossOrigin 属性

--- a/packages/react-full/src/components/Cover/index.tsx
+++ b/packages/react-full/src/components/Cover/index.tsx
@@ -80,6 +80,9 @@ export const Cover: ForwardRefExoticComponent<
 			return;
 		}, []);
 
+		const isRemoteUrl =
+			coverUrl?.startsWith("http://") || coverUrl?.startsWith("https://");
+
 		return (
 			<div
 				className={clsNames}
@@ -111,7 +114,7 @@ export const Cover: ForwardRefExoticComponent<
 							loop
 							muted
 							playsInline
-							crossOrigin="anonymous"
+							crossOrigin={isRemoteUrl ? "anonymous" : undefined}
 							ref={videoRef}
 						/>
 					) : (


### PR DESCRIPTION
只为远程资源设置 crossOrigin 属性，以免本地资源因未配置 CORS 头而报错