### PR TITLE
fix(core): 修复 ruby base 包含多个 CJK 字符时意外换行

### DIFF
--- a/.nx/version-plans/version-plan-1785779889595.md
+++ b/.nx/version-plans/version-plan-1785779889595.md
@@ -1,0 +1,5 @@
+---
+core-bundle: patch
+---
+
+fix(core): 修复 ruby base 包含多个 CJK 字符时意外换行

--- a/packages/core/src/styles/lyric-player.module.css
+++ b/packages/core/src/styles/lyric-player.module.css
@@ -113,7 +113,7 @@
 
 	.wordBody {
 		display: flex;
-		flex-direction: column;
+		flex-direction: row;
 		align-items: center;
 	}
 


### PR DESCRIPTION
将 wordBody 的 flex-direction 从 column 改为 row，以修复 CJK 文本在 ruby 内排列不正确