### PR TITLE
fix(core): 修复前置背景人声的样式

### DIFF
--- a/.nx/version-plans/version-plan-1786209007166.md
+++ b/.nx/version-plans/version-plan-1786209007166.md
@@ -1,0 +1,5 @@
+---
+core-bundle: patch
+---
+
+fix(core): 修复前置背景人声的样式

--- a/packages/core/src/lyric-player/dom/lyric-group.ts
+++ b/packages/core/src/lyric-player/dom/lyric-group.ts
@@ -100,7 +100,11 @@ export class LyricLineGroup extends LyricLineGroupBase<LyricLineEl> {
 	override onLineSizeChange(size: [number, number]): void {
 		super.onLineSizeChange(size);
 		if (this.bgWrapper) {
-			this.lastBgHeight = this.bgWrapper.clientHeight || 0;
+			const newBgHeight = this.bgWrapper.clientHeight || 0;
+			if (this.lastBgHeight !== newBgHeight) {
+				this.lastBgHeight = newBgHeight;
+				this.lastBgSlideYNum = -9999;
+			}
 		}
 	}
 
@@ -176,8 +180,13 @@ export class LyricLineGroup extends LyricLineGroupBase<LyricLineEl> {
 			}
 
 			const bgStyle = this.bgWrapper.style;
-			const slideY = this.bgSlideY.getCurrentPosition();
+			const currentBgHeight = this.bgWrapper.clientHeight || 0;
+			if (currentBgHeight > 0 && this.lastBgHeight !== currentBgHeight) {
+				this.lastBgHeight = currentBgHeight;
+				this.lastBgSlideYNum = -9999;
+			}
 
+			const slideY = this.bgSlideY.getCurrentPosition();
 			if (Math.abs(slideY - this.lastBgSlideYNum) >= 0.001) {
 				this.lastBgSlideYNum = slideY;
 				const activeProgress = clamp01(1 - Math.abs(slideY) / 80);
@@ -186,12 +195,15 @@ export class LyricLineGroup extends LyricLineGroupBase<LyricLineEl> {
 					this.lyricPlayer.getAlwaysPostpositionBackground();
 				const shouldBgFirst = !alwaysPostposition && this.isBgFirst;
 
-				let finalTranslateYPx = (slideY / 100) * this.lastBgHeight;
+				const translateYPx = (slideY / 100) * this.lastBgHeight;
 				if (shouldBgFirst) {
-					finalTranslateYPx += -this.lastBgHeight * (1 - activeProgress);
+					const currentMarginTop = -this.lastBgHeight * (1 - activeProgress);
+					bgStyle.marginTop = `${currentMarginTop.toFixed(1)}px`;
+				} else {
+					bgStyle.marginTop = "";
 				}
 
-				bgStyle.transform = `translateY(${finalTranslateYPx.toFixed(1)}px) scale(${scaleStr})`;
+				bgStyle.transform = `translateY(${translateYPx.toFixed(1)}px) scale(${scaleStr})`;
 
 				const targetHiddenY = shouldBgFirst ? 80 : -80;
 				const isHidden =

--- a/packages/core/src/styles/lyric-player.module.css
+++ b/packages/core/src/styles/lyric-player.module.css
@@ -219,7 +219,6 @@
 	width: 100%;
 	top: auto;
 	bottom: auto;
-	margin-top: -999px;
 	transform-origin: left bottom;
 }
 


### PR DESCRIPTION
修复了：

* 之前忘记删掉的 `margin-top: -999px;` 导致布局崩坏
* 未折叠前置背景人声导致未激活的前置背景人声依在主歌词上方留出一片空白
* 初次测量视口外的歌词导致获得 0px 高度并锁死缓存