### PR TITLE
feat(playground): 添加 Isolation 背景渲染器

### DIFF
--- a/packages/playground/core/src/components/BackgroundController.vue
+++ b/packages/playground/core/src/components/BackgroundController.vue
@@ -1,5 +1,9 @@
 <script setup lang="ts">
-import { BrushIcon, MonitorPlayIcon } from "lucide-vue-next";
+import {
+	BrushIcon,
+	MonitorPlayIcon,
+	SlidersHorizontalIcon,
+} from "lucide-vue-next";
 import {
 	Select,
 	SelectContent,
@@ -49,6 +53,7 @@ const player = usePlayerStore();
 				<SelectContent>
 					<SelectItem value="mg">Mesh Gradient 渲染器</SelectItem>
 					<SelectItem value="pixi">Pixi 渲染器</SelectItem>
+					<SelectItem value="isolation">Isolation 渲染器</SelectItem>
 				</SelectContent>
 			</Select>
 
@@ -79,5 +84,36 @@ const player = usePlayerStore();
 				/>
 			</ControllerSliderGroup>
 		</section>
+
+		<template v-if="player.background.renderer === 'isolation'">
+			<Separator />
+
+			<section class="space-y-2.5">
+				<h3 class="text-sm font-bold flex items-center gap-1">
+					<SlidersHorizontalIcon :size="16" />
+					Isolation 选项
+				</h3>
+				<Select v-model="player.background.isolation.paletteAlgorithm">
+					<SelectTrigger class="w-full">
+						<SelectValue placeholder="取色算法" />
+					</SelectTrigger>
+				<SelectContent>
+					<SelectItem value="auto">自动择优（K-Means / 八叉树）</SelectItem>
+						<SelectItem value="kmeans">K-Means</SelectItem>
+						<SelectItem value="octtree">八叉树</SelectItem>
+					</SelectContent>
+				</Select>
+				<ControllerSwitch
+					v-model="player.background.isolation.lightWave"
+					title="光波效果"
+					description="让渐变的明度随时间波动"
+				/>
+				<ControllerSwitch
+					v-model="player.background.isolation.dithering"
+					title="抖动"
+					description="叠加极弱噪声消除渐变色带"
+				/>
+			</section>
+		</template>
 	</div>
 </template>

--- a/packages/playground/core/src/components/MainPlayer.vue
+++ b/packages/playground/core/src/components/MainPlayer.vue
@@ -249,6 +249,9 @@ watch(
 		player.background.flowSpeed,
 		player.background.staticMode,
 		player.background.playing,
+		player.background.isolation.lightWave,
+		player.background.isolation.dithering,
+		player.background.isolation.paletteAlgorithm,
 	],
 	() => backgroundRuntime.applySettings(player),
 );

--- a/packages/playground/core/src/runtime/background.ts
+++ b/packages/playground/core/src/runtime/background.ts
@@ -1,17 +1,23 @@
 import {
 	BackgroundRender,
+	type BaseRenderer,
+	IsolationRenderer,
 	MeshGradientRenderer,
 	PixiRenderer,
 } from "@applemusic-like-lyrics/core";
 import type { BackgroundRendererMode, usePlayerStore } from "@/stores/player";
 
 type PlayerStore = ReturnType<typeof usePlayerStore>;
-type PlayerBackground =
-	| BackgroundRender<MeshGradientRenderer>
-	| BackgroundRender<PixiRenderer>;
+type RendererConstructor = new (canvas: HTMLCanvasElement) => BaseRenderer;
+
+const RENDERERS: Record<BackgroundRendererMode, RendererConstructor> = {
+	mg: MeshGradientRenderer,
+	pixi: PixiRenderer,
+	isolation: IsolationRenderer,
+};
 
 class BackgroundRuntime {
-	private background: PlayerBackground | undefined;
+	private background: BackgroundRender<BaseRenderer> | undefined;
 	private renderer: BackgroundRendererMode | undefined;
 	private albumKey = "";
 	private albumLoadRevision = 0;
@@ -33,10 +39,7 @@ class BackgroundRuntime {
 		if (this.background && this.renderer === renderer) return;
 
 		this.background?.dispose();
-		this.background =
-			renderer === "pixi"
-				? BackgroundRender.new(PixiRenderer)
-				: BackgroundRender.new(MeshGradientRenderer);
+		this.background = BackgroundRender.new(RENDERERS[renderer]);
 		this.renderer = renderer;
 		this.albumKey = "";
 
@@ -61,6 +64,12 @@ class BackgroundRuntime {
 		background.setStaticMode(store.background.staticMode);
 		if (store.background.playing) background.resume();
 		else background.pause();
+
+		// 渲染器专属选项走实例本体，统一接口里没有对应的方法
+		const renderer = background.getRenderer();
+		if (renderer instanceof IsolationRenderer) {
+			renderer.setOptions(store.background.isolation);
+		}
 	}
 
 	setHasLyric(hasLyric: boolean): void {

--- a/packages/playground/core/src/stores/player.ts
+++ b/packages/playground/core/src/stores/player.ts
@@ -1,6 +1,7 @@
+import type { PaletteAlgorithm } from "@applemusic-like-lyrics/core";
 import { defineStore } from "pinia";
 
-export type BackgroundRendererMode = "mg" | "pixi";
+export type BackgroundRendererMode = "mg" | "pixi" | "isolation";
 
 export interface SpringParams {
 	mass: number;
@@ -72,10 +73,17 @@ export const usePlayerStore = defineStore("player", {
 			staticMode: false,
 			renderer: (query.get("bg") === "pixi"
 				? "pixi"
-				: "mg") as BackgroundRendererMode,
+				: query.get("bg") === "isolation"
+					? "isolation"
+					: "mg") as BackgroundRendererMode,
 			scale: 1,
 			fps: 60,
 			flowSpeed: 0.2,
+			isolation: {
+				lightWave: false,
+				dithering: true,
+				paletteAlgorithm: "auto" as PaletteAlgorithm,
+			},
 			error: "",
 		},
 	}),


### PR DESCRIPTION
## PR Summary

本 PR 是「Isolation 背景渲染器」系列堆叠 PR 的 **第 4 层（playground 集成）**，依赖 #603、#604、#605。四层均直接基于 `main`、修改文件互不重叠，请按文末表格顺序审查合并。

### 本层改动

- 在背景渲染器选择中加入 Isolation 渲染器选项
- 添加 Isolation 专属设置项：取色算法、Light Wave 光波效果与 Dithering 抖动
- 通过注册表统一管理渲染器实例，并在应用设置时根据渲染器类型调用实例专属配置方法

### 审查说明

- 依赖 #603、#604、#605，合并顺序为 #603 → #604 → #605 → 本 PR
- 本分支直接基于 `main`（fork 无法选择上层 PR 作为 base），合并前请确保前三层已合入
- 原 #602 的完整改动已按层拆分为以下 4 个 PR：

| 顺序 | PR | 内容 |
| --- | --- | --- |
| 1 | #603 | core：WebGL 基础设施与封面取色 |
| 2 | #604 | core：Isolation 渲染器 |
| 3 | #605 | react / react-full 集成 |
| 4 | 本 PR | playground 集成 |
