### PR TITLE
feat(core): 添加 WebGL 基础设施与封面取色工具

### DIFF
--- a/packages/core/src/bg-render/gl-program.ts
+++ b/packages/core/src/bg-render/gl-program.ts
@@ -1,0 +1,164 @@
+import type { Disposable } from "../interfaces.ts";
+
+/**
+ * 着色器程序可用的渲染上下文。
+ *
+ * 目前的背景渲染器以 WebGL1 为主，但这个封装本身不依赖特定版本，所以两者
+ * 都接受。
+ */
+export type GLRenderingContext = WebGLRenderingContext | WebGL2RenderingContext;
+
+/**
+ * 对 WebGL 着色器程序的一层薄封装，负责编译、链接、缓存 uniform 位置。
+ */
+export class GLProgram implements Disposable {
+	private gl: GLRenderingContext;
+	program: WebGLProgram;
+	private vertexShader: WebGLShader;
+	private fragmentShader: WebGLShader;
+	readonly attrs: { [name: string]: number };
+	private uniformLocations = new Map<string, WebGLUniformLocation | null>();
+	constructor(
+		gl: GLRenderingContext,
+		vertexShaderSource: string,
+		fragmentShaderSource: string,
+		private readonly label = "unknown",
+	) {
+		this.gl = gl;
+		const vertexShader = this.createShader(
+			gl.VERTEX_SHADER,
+			vertexShaderSource,
+		);
+		let fragmentShader: WebGLShader | undefined;
+		try {
+			fragmentShader = this.createShader(
+				gl.FRAGMENT_SHADER,
+				fragmentShaderSource,
+			);
+			this.program = this.createProgram(vertexShader, fragmentShader);
+		} catch (error) {
+			gl.deleteShader(vertexShader);
+			if (fragmentShader) gl.deleteShader(fragmentShader);
+			throw error;
+		}
+		this.vertexShader = vertexShader;
+		this.fragmentShader = fragmentShader;
+
+		const num = gl.getProgramParameter(this.program, gl.ACTIVE_ATTRIBUTES);
+		const attrs: { [name: string]: number } = {};
+		for (let i = 0; i < num; i++) {
+			const info = gl.getActiveAttrib(this.program, i);
+			if (!info) continue;
+			const location = gl.getAttribLocation(this.program, info.name);
+			if (location === -1) continue;
+			attrs[info.name] = location;
+		}
+		this.attrs = attrs;
+	}
+	private createShader(type: number, source: string): WebGLShader {
+		const gl = this.gl;
+		const shader = gl.createShader(type);
+		if (!shader) throw new Error("Failed to create shader");
+		gl.shaderSource(shader, source);
+		gl.compileShader(shader);
+		if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+			const error = new Error(
+				`Failed to compile shader for type ${type} "${
+					this.label
+				}": ${gl.getShaderInfoLog(shader)}`,
+			);
+			gl.deleteShader(shader);
+			throw error;
+		}
+		return shader;
+	}
+	private createProgram(
+		vertexShader: WebGLShader,
+		fragmentShader: WebGLShader,
+	): WebGLProgram {
+		const gl = this.gl;
+		const program = gl.createProgram();
+		if (!program) throw new Error("Failed to create program");
+		gl.attachShader(program, vertexShader);
+		gl.attachShader(program, fragmentShader);
+		gl.linkProgram(program);
+		if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+			const errLog = gl.getProgramInfoLog(program);
+			gl.deleteProgram(program);
+			throw new Error(`Failed to link program "${this.label}": ${errLog}`);
+		}
+		return program;
+	}
+	use(): void {
+		const gl = this.gl;
+		gl.useProgram(this.program);
+	}
+	private notFoundUniforms: Set<string> = new Set();
+	private warnUniformNotFound(name: string): void {
+		if (this.notFoundUniforms.has(name)) return;
+		this.notFoundUniforms.add(name);
+		console.warn(
+			`Failed to get uniform location for program "${this.label}": ${name}`,
+		);
+	}
+	/**
+	 * 取 uniform 位置并缓存。逐帧设置几十个 uniform 时，省下的
+	 * `getUniformLocation` 调用相当可观。
+	 */
+	private getUniformLocation(name: string): WebGLUniformLocation | null {
+		let location = this.uniformLocations.get(name);
+		if (location === undefined) {
+			location = this.gl.getUniformLocation(this.program, name);
+			this.uniformLocations.set(name, location);
+		}
+		if (location === null) this.warnUniformNotFound(name);
+		return location;
+	}
+	setUniform1f(name: string, value: number): void {
+		const location = this.getUniformLocation(name);
+		if (location !== null) this.gl.uniform1f(location, value);
+	}
+	setUniform2f(name: string, value1: number, value2: number): void {
+		const location = this.getUniformLocation(name);
+		if (location !== null) this.gl.uniform2f(location, value1, value2);
+	}
+	setUniform3f(
+		name: string,
+		value1: number,
+		value2: number,
+		value3: number,
+	): void {
+		const location = this.getUniformLocation(name);
+		if (location !== null) this.gl.uniform3f(location, value1, value2, value3);
+	}
+	setUniform4f(
+		name: string,
+		value1: number,
+		value2: number,
+		value3: number,
+		value4: number,
+	): void {
+		const location = this.getUniformLocation(name);
+		if (location !== null)
+			this.gl.uniform4f(location, value1, value2, value3, value4);
+	}
+	setUniform1i(name: string, value: number): void {
+		const location = this.getUniformLocation(name);
+		if (location !== null) this.gl.uniform1i(location, value);
+	}
+	setUniform1fv(name: string, value: Float32Array): void {
+		const location = this.getUniformLocation(name);
+		if (location !== null) this.gl.uniform1fv(location, value);
+	}
+	setUniform3fv(name: string, value: Float32Array): void {
+		const location = this.getUniformLocation(name);
+		if (location !== null) this.gl.uniform3fv(location, value);
+	}
+	dispose(): void {
+		const gl = this.gl;
+		gl.deleteShader(this.vertexShader);
+		gl.deleteShader(this.fragmentShader);
+		gl.deleteProgram(this.program);
+		this.uniformLocations.clear();
+	}
+}

--- a/packages/core/src/bg-render/mesh-renderer/index.ts
+++ b/packages/core/src/bg-render/mesh-renderer/index.ts
@@ -6,18 +6,20 @@
  */
 
 import { Mat4, Vec2, Vec3, Vec4 } from "gl-matrix";
+import { createOffscreenCanvas } from "#utils/canvas.ts";
+import { clamp01 } from "#utils/clamp.ts";
 import type { Disposable } from "../../interfaces.ts";
 import {
 	loadResourceFromElement,
 	loadResourceFromUrl,
 } from "../../utils/resource.ts";
 import { BaseRenderer } from "../base.ts";
+import { GLProgram } from "../gl-program.ts";
 import { blurImage } from "../img.ts";
 import { generateControlPoints } from "./cp-generate.ts";
 import { CONTROL_POINT_PRESETS } from "./cp-presets.ts";
 import meshFragShader from "./mesh.frag.glsl?raw";
 import meshVertShader from "./mesh.vert.glsl?raw";
-import { clamp01 } from "#utils/clamp.ts";
 
 const quadVertShader = `
 attribute vec2 a_pos;
@@ -44,105 +46,6 @@ function easeInOutSine(x: number): number {
 }
 
 type RenderingContext = WebGLRenderingContext;
-
-class GLProgram implements Disposable {
-	private gl: RenderingContext;
-	program: WebGLProgram;
-	private vertexShader: WebGLShader;
-	private fragmentShader: WebGLShader;
-	readonly attrs: { [name: string]: number };
-	constructor(
-		gl: RenderingContext,
-		vertexShaderSource: string,
-		fragmentShaderSource: string,
-		private readonly label = "unknown",
-	) {
-		this.gl = gl;
-		this.vertexShader = this.createShader(gl.VERTEX_SHADER, vertexShaderSource);
-		this.fragmentShader = this.createShader(
-			gl.FRAGMENT_SHADER,
-			fragmentShaderSource,
-		);
-		this.program = this.createProgram();
-
-		const num = gl.getProgramParameter(this.program, gl.ACTIVE_ATTRIBUTES);
-		const attrs: { [name: string]: number } = {};
-		for (let i = 0; i < num; i++) {
-			const info = gl.getActiveAttrib(this.program, i);
-			if (!info) continue;
-			const location = gl.getAttribLocation(this.program, info.name);
-			if (location === -1) continue;
-			attrs[info.name] = location;
-		}
-		this.attrs = attrs;
-	}
-	private createShader(type: number, source: string) {
-		const gl = this.gl;
-		const shader = gl.createShader(type);
-		if (!shader) throw new Error("Failed to create shader");
-		gl.shaderSource(shader, source);
-		gl.compileShader(shader);
-		if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
-			throw new Error(
-				`Failed to compile shader for type ${type} "${
-					this.label
-				}": ${gl.getShaderInfoLog(shader)}`,
-			);
-		}
-		return shader;
-	}
-	private createProgram() {
-		const gl = this.gl;
-		const program = gl.createProgram();
-		if (!program) throw new Error("Failed to create program");
-		gl.attachShader(program, this.vertexShader);
-		gl.attachShader(program, this.fragmentShader);
-		gl.linkProgram(program);
-		gl.validateProgram(program);
-		if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
-			const errLog = gl.getProgramInfoLog(program);
-			gl.deleteProgram(program);
-			throw new Error(`Failed to link program "${this.label}": ${errLog}`);
-		}
-		return program;
-	}
-	use() {
-		const gl = this.gl;
-		gl.useProgram(this.program);
-	}
-	private notFoundUniforms: Set<string> = new Set();
-	private warnUniformNotFound(name: string) {
-		if (this.notFoundUniforms.has(name)) return;
-		this.notFoundUniforms.add(name);
-		console.warn(
-			`Failed to get uniform location for program "${this.label}": ${name}`,
-		);
-	}
-	setUniform1f(name: string, value: number) {
-		const gl = this.gl;
-		const location = gl.getUniformLocation(this.program, name);
-		if (!location) this.warnUniformNotFound(name);
-		else gl.uniform1f(location, value);
-	}
-	setUniform2f(name: string, value1: number, value2: number) {
-		const gl = this.gl;
-		const location = gl.getUniformLocation(this.program, name);
-		if (!location) this.warnUniformNotFound(name);
-		else gl.uniform2f(location, value1, value2);
-	}
-	setUniform1i(name: string, value: number) {
-		const gl = this.gl;
-		const location = gl.getUniformLocation(this.program, name);
-		if (!location) this.warnUniformNotFound(name);
-		else gl.uniform1i(location, value);
-	}
-	dispose() {
-		const gl = this.gl;
-		gl.deleteShader(this.vertexShader);
-		gl.deleteShader(this.fragmentShader);
-		gl.deleteProgram(this.program);
-	}
-}
 
 class Mesh implements Disposable {
 	protected vertexWidth = 0;
@@ -761,14 +664,6 @@ class GLTexture implements Disposable {
 	dispose(): void {
 		this.gl.deleteTexture(this.tex);
 	}
-}
-
-function createOffscreenCanvas(width: number, height: number) {
-	if ("OffscreenCanvas" in window) return new OffscreenCanvas(width, height);
-	const canvas = document.createElement("canvas");
-	canvas.width = width;
-	canvas.height = height;
-	return canvas;
 }
 
 interface MeshState {

--- a/packages/core/src/bg-render/palette/auto.ts
+++ b/packages/core/src/bg-render/palette/auto.ts
@@ -4,6 +4,8 @@
  *
  * 逐行移植自 Storyteller-Studios/Impressionist（MIT）的
  * `Impressionist/Implementations/AutoPaletteGenerator.cs`。
+ *
+ * @see https://github.com/Storyteller-Studios/Impressionist/blob/master/Impressionist/Implementations/AutoPaletteGenerator.cs
  */
 
 import { rgbToLab } from "./color-utilities.ts";

--- a/packages/core/src/bg-render/palette/auto.ts
+++ b/packages/core/src/bg-render/palette/auto.ts
@@ -1,0 +1,84 @@
+/**
+ * @fileoverview
+ * 自动在 K-Means 与八叉树两种取色结果之间择优。
+ *
+ * 逐行移植自 Storyteller-Studios/Impressionist（MIT）的
+ * `Impressionist/Implementations/AutoPaletteGenerator.cs`。
+ */
+
+import { rgbToLab } from "./color-utilities.ts";
+import {
+	createKMeansPalette,
+	createRandom,
+	createThemeColor,
+	seedFromHistogram,
+} from "./kmeans.ts";
+import { createOctTreePalette } from "./octtree.ts";
+import type { ColorCount, ColorVec3, PaletteResult } from "./types.ts";
+
+/** 调色板在 LAB 空间里到自身质心的平均平方距离，用来衡量色彩分散程度。 */
+function calculateSpatialDiversity(palette: readonly ColorVec3[]): number {
+	if (palette.length === 0) return 0;
+
+	const labVectors = palette.map(rgbToLab);
+	let centroidL = 0;
+	let centroidA = 0;
+	let centroidB = 0;
+	for (const [l, a, b] of labVectors) {
+		centroidL += l;
+		centroidA += a;
+		centroidB += b;
+	}
+	centroidL /= labVectors.length;
+	centroidA /= labVectors.length;
+	centroidB /= labVectors.length;
+
+	let sumSquaredDistances = 0;
+	for (const [l, a, b] of labVectors) {
+		const dl = l - centroidL;
+		const da = a - centroidA;
+		const db = b - centroidB;
+		sumSquaredDistances += dl * dl + da * da + db * db;
+	}
+	return sumSquaredDistances / labVectors.length;
+}
+
+/**
+ * 同时跑两种取色算法并择优：暗色调色板偏好更分散的结果，亮色调色板反之偏好
+ * 更聚拢的结果（八叉树在亮色上容易退化成一片惨白，所以 0 分散度直接判负）。
+ */
+export function createAutoPalette(
+	sourceColors: readonly ColorCount[],
+	clusterCount: number,
+	ignoreWhite = false,
+	toLab = false,
+	useKMeansPP = false,
+): PaletteResult {
+	const random = createRandom(seedFromHistogram(sourceColors));
+	const themeColor = createThemeColor(sourceColors, ignoreWhite, toLab, random);
+	const kmeansResult = createKMeansPalette(
+		sourceColors,
+		clusterCount,
+		themeColor,
+		ignoreWhite,
+		toLab,
+		useKMeansPP,
+		random,
+	);
+	const octTreeResult = createOctTreePalette(
+		sourceColors,
+		clusterCount,
+		themeColor,
+		ignoreWhite,
+	);
+
+	const kMeansDiversity = calculateSpatialDiversity(kmeansResult.palette);
+	const octTreeDiversity = calculateSpatialDiversity(octTreeResult.palette);
+
+	if (kmeansResult.paletteIsDark) {
+		return kMeansDiversity >= octTreeDiversity ? kmeansResult : octTreeResult;
+	}
+	return kMeansDiversity <= octTreeDiversity || octTreeDiversity === 0
+		? kmeansResult
+		: octTreeResult;
+}

--- a/packages/core/src/bg-render/palette/color-utilities.ts
+++ b/packages/core/src/bg-render/palette/color-utilities.ts
@@ -1,0 +1,160 @@
+/**
+ * @fileoverview
+ * 色彩空间转换与明暗判定。
+ *
+ * 逐行移植自 Storyteller-Studios/Impressionist（MIT）的
+ * `Impressionist/Implementations/ColorUtilities.cs`。
+ */
+
+import type { ColorVec3, HSVColor } from "./types.ts";
+
+export function rgbToHsv(color: ColorVec3): HSVColor {
+	const [r, g, b] = color;
+	const max = Math.max(r, g, b);
+	const min = Math.min(r, g, b);
+
+	const v = (max * 100) / 255;
+	if (max === min) return { h: 0, s: 0, v };
+
+	const s = ((max - min) / max) * 100;
+	let h = 0;
+	if (max === r) {
+		h = (60 * (g - b)) / (max - min);
+	} else if (max === g) {
+		h = 60 * (2 + (b - r) / (max - min));
+	} else {
+		h = 60 * (4 + (r - g) / (max - min));
+	}
+	if (h < 0) h += 360;
+	return { h, s, v };
+}
+
+export function hsvToRgb(hsv: HSVColor): ColorVec3 {
+	const h = hsv.h === 360 ? 0 : hsv.h;
+	const hi = Math.floor(h / 60) % 6;
+	const f = h / 60 - hi;
+	const p = (hsv.v / 100) * (1 - hsv.s / 100) * 255;
+	const q = (hsv.v / 100) * (1 - f * (hsv.s / 100)) * 255;
+	const t = (hsv.v / 100) * (1 - (1 - f) * (hsv.s / 100)) * 255;
+	const v = (hsv.v * 255) / 100;
+
+	switch (hi) {
+		case 0:
+			return [v, t, p];
+		case 1:
+			return [q, v, p];
+		case 2:
+			return [p, v, t];
+		case 3:
+			return [p, q, v];
+		case 4:
+			return [t, p, v];
+		default:
+			return [v, p, q];
+	}
+}
+
+export function rgbToXyz(rgb: ColorVec3): ColorVec3 {
+	const r = rgb[0] / 255;
+	const g = rgb[1] / 255;
+	const b = rgb[2] / 255;
+	return [
+		r * 0.4124 + g * 0.3576 + b * 0.1805,
+		r * 0.2126 + g * 0.7152 + b * 0.0722,
+		r * 0.0193 + g * 0.1192 + b * 0.9505,
+	];
+}
+
+export function xyzToRgb(xyz: ColorVec3): ColorVec3 {
+	const [x, y, z] = xyz;
+	return [
+		(x * 3.2406 - y * 1.5372 - z * 0.4986) * 255,
+		(-x * 0.9689 + y * 1.8758 + z * 0.0415) * 255,
+		(x * 0.0557 - y * 0.204 + z * 1.057) * 255,
+	];
+}
+
+const D65_X = 0.95047;
+const D65_Y = 1;
+const D65_Z = 1.0883;
+
+function fxyz(t: number): number {
+	return t > 0.008856 ? t ** (1 / 3) : 7.787 * t + 16 / 116;
+}
+
+export function xyzToLab(xyz: ColorVec3): ColorVec3 {
+	const [x, y, z] = xyz;
+	return [
+		116 * fxyz(y / D65_Y) - 16,
+		500 * (fxyz(x / D65_X) - fxyz(y / D65_Y)),
+		200 * (fxyz(y / D65_Y) - fxyz(z / D65_Z)),
+	];
+}
+
+export function labToXyz(lab: ColorVec3): ColorVec3 {
+	const delta = 6 / 29;
+	const [l, a, b] = lab;
+	const fy = (l + 16) / 116;
+	const fx = fy + a / 500;
+	const fz = fy - b / 200;
+	return [
+		fx > delta
+			? D65_X * fx * fx * fx
+			: (fx - 16 / 116) * 3 * delta * delta * D65_X,
+		fy > delta
+			? D65_Y * fy * fy * fy
+			: (fy - 16 / 116) * 3 * delta * delta * D65_Y,
+		fz > delta
+			? D65_Z * fz * fz * fz
+			: (fz - 16 / 116) * 3 * delta * delta * D65_Z,
+	];
+}
+
+export function rgbToLab(rgb: ColorVec3): ColorVec3 {
+	return xyzToLab(rgbToXyz(rgb));
+}
+
+export function labToRgb(lab: ColorVec3): ColorVec3 {
+	return xyzToRgb(labToXyz(lab));
+}
+
+export function channelToLinear(value: number): number {
+	return value <= 0.04045 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4;
+}
+
+export function yToLStar(y: number): number {
+	// CIE 标准写的是 0.008856 与 903.3，但 216/24389 和 24389/27 才是其本意
+	if (y <= 216 / 24389) return y * (24389 / 27);
+	return y ** (1 / 3) * 116 - 16;
+}
+
+function lStar(rgb: ColorVec3): number {
+	const y =
+		0.2126 * channelToLinear(rgb[0] / 255) +
+		0.7152 * channelToLinear(rgb[1] / 255) +
+		0.0722 * channelToLinear(rgb[2] / 255);
+	return yToLStar(y);
+}
+
+/** 调色板取色时判定「暗色候选」的阈值，比主题色判定更严格。 */
+export function paletteRgbLStarIsDark(rgb: ColorVec3): boolean {
+	return lStar(rgb) <= 40;
+}
+
+/** 调色板取色时判定「亮色候选」的阈值。 */
+export function paletteRgbLStarIsLight(rgb: ColorVec3): boolean {
+	return lStar(rgb) >= 60;
+}
+
+/** 主题色的明暗判定。 */
+export function rgbLStarIsDark(rgb: ColorVec3): boolean {
+	return lStar(rgb) <= 50;
+}
+
+/** 两个颜色向量的欧氏距离平方。 */
+export function distanceSquared(a: ColorVec3, b: ColorVec3): number {
+	const dx = a[0] - b[0];
+	const dy = a[1] - b[1];
+	const dz = a[2] - b[2];
+	return dx * dx + dy * dy + dz * dz;
+}

--- a/packages/core/src/bg-render/palette/color-utilities.ts
+++ b/packages/core/src/bg-render/palette/color-utilities.ts
@@ -4,6 +4,8 @@
  *
  * 逐行移植自 Storyteller-Studios/Impressionist（MIT）的
  * `Impressionist/Implementations/ColorUtilities.cs`。
+ *
+ * @see https://github.com/Storyteller-Studios/Impressionist/blob/master/Impressionist/Implementations/ColorUtilities.cs
  */
 
 import type { ColorVec3, HSVColor } from "./types.ts";
@@ -38,26 +40,22 @@ export function hsvToRgb(hsv: HSVColor): ColorVec3 {
 	const t = (hsv.v / 100) * (1 - (1 - f) * (hsv.s / 100)) * 255;
 	const v = (hsv.v * 255) / 100;
 
-	switch (hi) {
-		case 0:
-			return [v, t, p];
-		case 1:
-			return [q, v, p];
-		case 2:
-			return [p, v, t];
-		case 3:
-			return [p, q, v];
-		case 4:
-			return [t, p, v];
-		default:
-			return [v, p, q];
-	}
+	const rgbLookup: readonly ColorVec3[] = [
+		[v, t, p],
+		[q, v, p],
+		[p, v, t],
+		[p, q, v],
+		[t, p, v],
+		[v, p, q],
+	];
+	return rgbLookup[hi] ?? [v, p, q];
 }
 
 export function rgbToXyz(rgb: ColorVec3): ColorVec3 {
-	const r = rgb[0] / 255;
-	const g = rgb[1] / 255;
-	const b = rgb[2] / 255;
+	const [red, green, blue] = rgb;
+	const r = red / 255;
+	const g = green / 255;
+	const b = blue / 255;
 	return [
 		r * 0.4124 + g * 0.3576 + b * 0.1805,
 		r * 0.2126 + g * 0.7152 + b * 0.0722,
@@ -74,20 +72,23 @@ export function xyzToRgb(xyz: ColorVec3): ColorVec3 {
 	];
 }
 
-const D65_X = 0.95047;
-const D65_Y = 1;
-const D65_Z = 1.0883;
+/** D65 标准光源的白点。 */
+const D65 = {
+	x: 0.95047,
+	y: 1.0,
+	z: 1.0883,
+} as const;
 
 function fxyz(t: number): number {
-	return t > 0.008856 ? t ** (1 / 3) : 7.787 * t + 16 / 116;
+	return t > 0.008856 ? Math.cbrt(t) : 7.787 * t + 16 / 116;
 }
 
 export function xyzToLab(xyz: ColorVec3): ColorVec3 {
 	const [x, y, z] = xyz;
 	return [
-		116 * fxyz(y / D65_Y) - 16,
-		500 * (fxyz(x / D65_X) - fxyz(y / D65_Y)),
-		200 * (fxyz(y / D65_Y) - fxyz(z / D65_Z)),
+		116 * fxyz(y / D65.y) - 16,
+		500 * (fxyz(x / D65.x) - fxyz(y / D65.y)),
+		200 * (fxyz(y / D65.y) - fxyz(z / D65.z)),
 	];
 }
 
@@ -99,14 +100,14 @@ export function labToXyz(lab: ColorVec3): ColorVec3 {
 	const fz = fy - b / 200;
 	return [
 		fx > delta
-			? D65_X * fx * fx * fx
-			: (fx - 16 / 116) * 3 * delta * delta * D65_X,
+			? D65.x * fx * fx * fx
+			: (fx - 16 / 116) * 3 * delta * delta * D65.x,
 		fy > delta
-			? D65_Y * fy * fy * fy
-			: (fy - 16 / 116) * 3 * delta * delta * D65_Y,
+			? D65.y * fy * fy * fy
+			: (fy - 16 / 116) * 3 * delta * delta * D65.y,
 		fz > delta
-			? D65_Z * fz * fz * fz
-			: (fz - 16 / 116) * 3 * delta * delta * D65_Z,
+			? D65.z * fz * fz * fz
+			: (fz - 16 / 116) * 3 * delta * delta * D65.z,
 	];
 }
 
@@ -125,14 +126,15 @@ export function channelToLinear(value: number): number {
 export function yToLStar(y: number): number {
 	// CIE 标准写的是 0.008856 与 903.3，但 216/24389 和 24389/27 才是其本意
 	if (y <= 216 / 24389) return y * (24389 / 27);
-	return y ** (1 / 3) * 116 - 16;
+	return Math.cbrt(y) * 116 - 16;
 }
 
 function lStar(rgb: ColorVec3): number {
+	const [r, g, b] = rgb;
 	const y =
-		0.2126 * channelToLinear(rgb[0] / 255) +
-		0.7152 * channelToLinear(rgb[1] / 255) +
-		0.0722 * channelToLinear(rgb[2] / 255);
+		0.2126 * channelToLinear(r / 255) +
+		0.7152 * channelToLinear(g / 255) +
+		0.0722 * channelToLinear(b / 255);
 	return yToLStar(y);
 }
 
@@ -153,8 +155,10 @@ export function rgbLStarIsDark(rgb: ColorVec3): boolean {
 
 /** 两个颜色向量的欧氏距离平方。 */
 export function distanceSquared(a: ColorVec3, b: ColorVec3): number {
-	const dx = a[0] - b[0];
-	const dy = a[1] - b[1];
-	const dz = a[2] - b[2];
+	const [ax, ay, az] = a;
+	const [bx, by, bz] = b;
+	const dx = ax - bx;
+	const dy = ay - by;
+	const dz = az - bz;
 	return dx * dx + dy * dy + dz * dz;
 }

--- a/packages/core/src/bg-render/palette/histogram.ts
+++ b/packages/core/src/bg-render/palette/histogram.ts
@@ -1,0 +1,86 @@
+/**
+ * @fileoverview
+ * 从图像资源构建颜色直方图，作为取色器的输入。
+ */
+
+import { createOffscreenCanvas } from "#utils/canvas.ts";
+import type { ColorCount, ColorVec3 } from "./types.ts";
+
+/** 可以用来取色的图像资源。 */
+export type HistogramSource =
+	| HTMLImageElement
+	| HTMLVideoElement
+	| ImageBitmap
+	| ImageData;
+
+/**
+ * 统计前先把图像缩到这个尺寸。
+ *
+ * 取色只关心整体色彩分布，64×64 已经足够，而且能把直方图规模压到几千项，
+ * 让后续的 K-Means 在几毫秒内跑完。
+ */
+const DEFAULT_SAMPLE_SIZE = 64;
+
+function toImageData(
+	source: HistogramSource,
+	sampleSize: number,
+): ImageData | null {
+	if (source instanceof ImageData) return source;
+
+	const [sourceWidth, sourceHeight] =
+		source instanceof HTMLVideoElement
+			? [source.videoWidth, source.videoHeight]
+			: source instanceof HTMLImageElement
+				? [source.naturalWidth, source.naturalHeight]
+				: [source.width, source.height];
+	if (sourceWidth <= 0 || sourceHeight <= 0) return null;
+
+	const normalizedSampleSize = Math.max(1, Math.floor(sampleSize));
+	const scale = Math.min(
+		1,
+		normalizedSampleSize / Math.max(sourceWidth, sourceHeight),
+	);
+	const width = Math.max(1, Math.round(sourceWidth * scale));
+	const height = Math.max(1, Math.round(sourceHeight * scale));
+
+	const canvas = createOffscreenCanvas(width, height);
+	const ctx = canvas.getContext("2d", {
+		willReadFrequently: true,
+	}) as OffscreenCanvasRenderingContext2D | CanvasRenderingContext2D | null;
+	if (!ctx) return null;
+	ctx.drawImage(source, 0, 0, width, height);
+	return ctx.getImageData(0, 0, width, height);
+}
+
+/**
+ * 构建颜色直方图。全透明像素会被跳过，半透明像素按原色计入。
+ *
+ * @param source 图像资源
+ * @param sampleSize 统计前缩放到的最长边像素数，默认 64
+ */
+export function buildColorHistogram(
+	source: HistogramSource,
+	sampleSize: number = DEFAULT_SAMPLE_SIZE,
+): ColorCount[] {
+	const imageData = toImageData(source, sampleSize);
+	if (!imageData) return [];
+
+	const { data } = imageData;
+	const counts = new Map<number, number>();
+	for (let i = 0; i < data.length; i += 4) {
+		if (data[i + 3] === 0) continue;
+		const key = (data[i] << 16) | (data[i + 1] << 8) | data[i + 2];
+		counts.set(key, (counts.get(key) ?? 0) + 1);
+	}
+
+	const entries: ColorCount[] = [];
+	for (const [key, count] of counts) {
+		const color: ColorVec3 = [
+			(key >> 16) & 0xff,
+			(key >> 8) & 0xff,
+			key & 0xff,
+		];
+		entries.push({ color, count });
+	}
+	return entries;
+}

--- a/packages/core/src/bg-render/palette/histogram.ts
+++ b/packages/core/src/bg-render/palette/histogram.ts
@@ -73,14 +73,12 @@ export function buildColorHistogram(
 		counts.set(key, (counts.get(key) ?? 0) + 1);
 	}
 
-	const entries: ColorCount[] = [];
-	for (const [key, count] of counts) {
+	return Array.from(counts, ([key, count]) => {
 		const color: ColorVec3 = [
 			(key >> 16) & 0xff,
 			(key >> 8) & 0xff,
 			key & 0xff,
 		];
-		entries.push({ color, count });
-	}
-	return entries;
+		return { color, count };
+	});
 }

--- a/packages/core/src/bg-render/palette/index.ts
+++ b/packages/core/src/bg-render/palette/index.ts
@@ -1,0 +1,132 @@
+/**
+ * @fileoverview
+ * 从专辑封面提取主色调色板。
+ *
+ * 移植自 Storyteller-Studios/Impressionist（MIT），
+ * 详见各实现文件顶部的说明。
+ *
+ * Isolation 渲染器需要四个主色来构造渐变，这个模块就是它的供色来源；
+ * 其它需要「封面主色」的场景也可以直接复用。
+ */
+
+export { createAutoPalette } from "./auto.ts";
+export {
+	channelToLinear,
+	hsvToRgb,
+	labToRgb,
+	labToXyz,
+	paletteRgbLStarIsDark,
+	paletteRgbLStarIsLight,
+	rgbLStarIsDark,
+	rgbToHsv,
+	rgbToLab,
+	rgbToXyz,
+	xyzToLab,
+	xyzToRgb,
+	yToLStar,
+} from "./color-utilities.ts";
+export type { HistogramSource } from "./histogram.ts";
+export { buildColorHistogram } from "./histogram.ts";
+export { createKMeansPalette, createThemeColor } from "./kmeans.ts";
+export { createOctTreePalette } from "./octtree.ts";
+export type {
+	ColorCount,
+	ColorVec3,
+	HSVColor,
+	PaletteResult,
+	ThemeColorResult,
+} from "./types.ts";
+
+import { createAutoPalette } from "./auto.ts";
+import { buildColorHistogram, type HistogramSource } from "./histogram.ts";
+import { createKMeansPalette, createThemeColor } from "./kmeans.ts";
+import { createOctTreePalette } from "./octtree.ts";
+import type { PaletteResult } from "./types.ts";
+
+/** 取色算法。 */
+export type PaletteAlgorithm = "auto" | "kmeans" | "octtree";
+
+/** {@link createPaletteFromImage} 的可选项。 */
+export interface CreatePaletteOptions {
+	/** 取色算法，默认 `"auto"`。 */
+	algorithm?: PaletteAlgorithm;
+	/** 是否忽略接近纯白的颜色，默认 `false`。 */
+	ignoreWhite?: boolean;
+	/** K-Means 是否在 LAB 空间聚类，默认 `false`。 */
+	toLab?: boolean;
+	/** K-Means 是否使用 K-Means++ 初始化，默认 `false`。 */
+	useKMeansPP?: boolean;
+	/** 统计直方图前缩放到的最长边像素数，默认 64。 */
+	sampleSize?: number;
+}
+
+/**
+ * 从图像资源提取指定数量的主色。
+ *
+ * 整个流程是同步的：封面会先被缩到 64×64 再统计，因此在主线程上通常只需要几
+ * 毫秒，不值得为它单独开一个 Worker。
+ *
+ * @param source 图像资源，可以是 img/video 元素、`ImageBitmap` 或 `ImageData`
+ * @param clusterCount 需要的颜色数量，返回的调色板长度恒等于该值
+ */
+export function createPaletteFromImage(
+	source: HistogramSource,
+	clusterCount: number,
+	options: CreatePaletteOptions = {},
+): PaletteResult {
+	const normalizedClusterCount = Math.max(0, Math.floor(clusterCount));
+	const {
+		algorithm = "auto",
+		ignoreWhite = false,
+		toLab = false,
+		useKMeansPP = false,
+		sampleSize,
+	} = options;
+
+	const entries = buildColorHistogram(source, sampleSize);
+	if (entries.length === 0) {
+		const themeColor = {
+			color: [0, 0, 0] as [number, number, number],
+			colorIsDark: true,
+		};
+		return {
+			palette: Array.from(
+				{ length: normalizedClusterCount },
+				() => [0, 0, 0] as [number, number, number],
+			),
+			paletteIsDark: true,
+			themeColor,
+		};
+	}
+
+	switch (algorithm) {
+		case "kmeans": {
+			const themeColor = createThemeColor(entries, ignoreWhite, toLab);
+			return createKMeansPalette(
+				entries,
+				normalizedClusterCount,
+				themeColor,
+				ignoreWhite,
+				toLab,
+				useKMeansPP,
+			);
+		}
+		case "octtree": {
+			const themeColor = createThemeColor(entries, ignoreWhite, true);
+			return createOctTreePalette(
+				entries,
+				normalizedClusterCount,
+				themeColor,
+				ignoreWhite,
+			);
+		}
+		default:
+			return createAutoPalette(
+				entries,
+				normalizedClusterCount,
+				ignoreWhite,
+				toLab,
+				useKMeansPP,
+			);
+	}
+}

--- a/packages/core/src/bg-render/palette/kmeans.ts
+++ b/packages/core/src/bg-render/palette/kmeans.ts
@@ -9,6 +9,8 @@
  * 与原实现的唯一差异是随机源：原版用全局 `Random`，这里改用按直方图内容播种的
  * mulberry32，使得同一张封面每次都得到完全相同的调色板，避免重启应用后背景配色
  * 发生肉眼可见的漂移。
+ *
+ * @see https://github.com/Storyteller-Studios/Impressionist/blob/master/Impressionist/Implementations/KMeansPaletteGenerator.cs
  */
 
 import {
@@ -45,7 +47,7 @@ export function createRandom(seed: number): RandomSource {
 export function seedFromHistogram(entries: readonly ColorCount[]): number {
 	let hash = 0x811c9dc5;
 	for (const { color, count } of entries) {
-		for (const value of [color[0], color[1], color[2], count]) {
+		for (const value of [...color, count]) {
 			hash ^= Math.round(value) & 0xffff;
 			hash = Math.imul(hash, 0x01000193) >>> 0;
 		}
@@ -54,7 +56,7 @@ export function seedFromHistogram(entries: readonly ColorCount[]): number {
 }
 
 function isNotNearWhite(color: ColorVec3): boolean {
-	return color[0] <= 250 || color[1] <= 250 || color[2] <= 250;
+	return color.some((channel) => channel <= 250);
 }
 
 function filterOrFallback(
@@ -91,7 +93,7 @@ function toLabEntries(entries: readonly ColorCount[]): ColorCount[] {
 }
 
 function colorsEqual(a: ColorVec3, b: ColorVec3): boolean {
-	return a[0] === b[0] && a[1] === b[1] && a[2] === b[2];
+	return a.every((value, i) => value === b[i]);
 }
 
 function findNearestCenterIndex(
@@ -201,9 +203,7 @@ function kMeansCluster(
 		const shuffled = entries.map((entry) => entry.color);
 		for (let i = shuffled.length - 1; i > 0; i--) {
 			const j = Math.floor(random() * (i + 1));
-			const tmp = shuffled[i];
-			shuffled[i] = shuffled[j];
-			shuffled[j] = tmp;
+			[shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
 		}
 		centers = shuffled.slice(0, clusterCount);
 	}

--- a/packages/core/src/bg-render/palette/kmeans.ts
+++ b/packages/core/src/bg-render/palette/kmeans.ts
@@ -1,0 +1,322 @@
+/**
+ * @fileoverview
+ * K-Means 取色器。
+ *
+ * 逐行移植自 Storyteller-Studios/Impressionist（MIT）的
+ * `Impressionist/Implementations/KMeansPaletteGenerator.cs`，
+ * 其本身衍生自 wieslawsoltes/PaletteGenerator。
+ *
+ * 与原实现的唯一差异是随机源：原版用全局 `Random`，这里改用按直方图内容播种的
+ * mulberry32，使得同一张封面每次都得到完全相同的调色板，避免重启应用后背景配色
+ * 发生肉眼可见的漂移。
+ */
+
+import {
+	distanceSquared,
+	labToRgb,
+	paletteRgbLStarIsDark,
+	paletteRgbLStarIsLight,
+	rgbLStarIsDark,
+	rgbToLab,
+} from "./color-utilities.ts";
+import type {
+	ColorCount,
+	ColorVec3,
+	PaletteResult,
+	ThemeColorResult,
+} from "./types.ts";
+
+/** 一个确定性的伪随机数发生器，返回 [0, 1) 区间的浮点数。 */
+export type RandomSource = () => number;
+
+/** mulberry32，短小且分布足够好。 */
+export function createRandom(seed: number): RandomSource {
+	let state = seed >>> 0;
+	return () => {
+		state = (state + 0x6d2b79f5) >>> 0;
+		let t = state;
+		t = Math.imul(t ^ (t >>> 15), t | 1);
+		t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+		return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+	};
+}
+
+/** 由直方图内容派生一个稳定的种子。 */
+export function seedFromHistogram(entries: readonly ColorCount[]): number {
+	let hash = 0x811c9dc5;
+	for (const { color, count } of entries) {
+		for (const value of [color[0], color[1], color[2], count]) {
+			hash ^= Math.round(value) & 0xffff;
+			hash = Math.imul(hash, 0x01000193) >>> 0;
+		}
+	}
+	return hash >>> 0;
+}
+
+function isNotNearWhite(color: ColorVec3): boolean {
+	return color[0] <= 250 || color[1] <= 250 || color[2] <= 250;
+}
+
+function filterOrFallback(
+	entries: readonly ColorCount[],
+	predicate: (entry: ColorCount) => boolean,
+): ColorCount[] {
+	const filtered = entries.filter(predicate);
+	return filtered.length > 0 ? filtered : [...entries];
+}
+
+function clampRgb(color: ColorVec3): ColorVec3 {
+	return color.map((channel) =>
+		Math.min(255, Math.max(0, channel)),
+	) as ColorVec3;
+}
+
+/** 把同色项合并计数，等价于 C# 里的 `GroupBy(...).ToDictionary(...)`。 */
+function groupColors(entries: readonly ColorCount[]): ColorCount[] {
+	const grouped = new Map<string, ColorCount>();
+	for (const entry of entries) {
+		const key = `${entry.color[0]},${entry.color[1]},${entry.color[2]}`;
+		const existing = grouped.get(key);
+		if (existing) existing.count += entry.count;
+		else grouped.set(key, { color: [...entry.color], count: entry.count });
+	}
+	return [...grouped.values()];
+}
+
+function toLabEntries(entries: readonly ColorCount[]): ColorCount[] {
+	return entries.map((entry) => ({
+		color: rgbToLab(entry.color),
+		count: entry.count,
+	}));
+}
+
+function colorsEqual(a: ColorVec3, b: ColorVec3): boolean {
+	return a[0] === b[0] && a[1] === b[1] && a[2] === b[2];
+}
+
+function findNearestCenterIndex(
+	color: ColorVec3,
+	centers: readonly ColorVec3[],
+): number {
+	let nearestIndex = 0;
+	let minDist = Number.POSITIVE_INFINITY;
+	for (let i = 0; i < centers.length; i++) {
+		const dist = distanceSquared(color, centers[i]);
+		if (dist < minDist) {
+			nearestIndex = i;
+			minDist = dist;
+		}
+	}
+	return nearestIndex;
+}
+
+function findFarthestColor(
+	entries: readonly ColorCount[],
+	centers: readonly ColorVec3[],
+): ColorVec3 {
+	let farthest: ColorVec3 = [0, 0, 0];
+	let maxDistance = Number.NEGATIVE_INFINITY;
+	for (const { color } of entries) {
+		let nearestDistance = Number.POSITIVE_INFINITY;
+		for (const center of centers) {
+			const dist = distanceSquared(color, center);
+			if (dist < nearestDistance) nearestDistance = dist;
+		}
+		if (nearestDistance > maxDistance) {
+			maxDistance = nearestDistance;
+			farthest = color;
+		}
+	}
+	return farthest;
+}
+
+function kMeansPlusPlusCenters(
+	entries: readonly ColorCount[],
+	clusterCount: number,
+	random: RandomSource,
+): ColorVec3[] {
+	const firstIndex = Math.floor(random() * entries.length);
+	const selectedIndices = new Set([firstIndex]);
+	const centers: ColorVec3[] = [entries[firstIndex].color];
+	for (let i = 1; i < clusterCount; i++) {
+		let accumulated = 0;
+		const accDistances = new Float64Array(entries.length);
+		for (let vectorId = 0; vectorId < entries.length; vectorId++) {
+			const target = entries[vectorId].color;
+			let minDistanceSquared = distanceSquared(centers[0], target);
+			for (let clusterIdx = 1; clusterIdx < i; clusterIdx++) {
+				const current = distanceSquared(centers[clusterIdx], target);
+				if (current < minDistanceSquared) minDistanceSquared = current;
+			}
+			accumulated += minDistanceSquared * entries[vectorId].count;
+			accDistances[vectorId] = accumulated;
+		}
+		if (accumulated <= Number.EPSILON) {
+			const nextIndex = entries.findIndex(
+				(_, index) => !selectedIndices.has(index),
+			);
+			if (nextIndex < 0) break;
+			selectedIndices.add(nextIndex);
+			centers.push(entries[nextIndex].color);
+			continue;
+		}
+
+		const targetPoint = random() * accumulated;
+		for (let vectorId = 0; vectorId < entries.length; vectorId++) {
+			if (
+				!selectedIndices.has(vectorId) &&
+				accDistances[vectorId] >= targetPoint
+			) {
+				selectedIndices.add(vectorId);
+				centers.push(entries[vectorId].color);
+				break;
+			}
+		}
+		if (centers.length === i) {
+			const nextIndex = entries.findIndex(
+				(_, index) => !selectedIndices.has(index),
+			);
+			if (nextIndex < 0) break;
+			selectedIndices.add(nextIndex);
+			centers.push(entries[nextIndex].color);
+		}
+	}
+	return centers;
+}
+
+function kMeansCluster(
+	entries: readonly ColorCount[],
+	numClusters: number,
+	useKMeansPP: boolean,
+	random: RandomSource,
+): ColorVec3[] {
+	const clusterCount = Math.min(numClusters, entries.length);
+	if (clusterCount <= 0) return [];
+
+	let centers: ColorVec3[];
+	if (useKMeansPP) {
+		centers = kMeansPlusPlusCenters(entries, clusterCount, random);
+	} else {
+		// 等价于 C# 的 OrderByDescending(_ => random.Next()).Take(clusterCount)
+		const shuffled = entries.map((entry) => entry.color);
+		for (let i = shuffled.length - 1; i > 0; i--) {
+			const j = Math.floor(random() * (i + 1));
+			const tmp = shuffled[i];
+			shuffled[i] = shuffled[j];
+			shuffled[j] = tmp;
+		}
+		centers = shuffled.slice(0, clusterCount);
+	}
+
+	const assignments = new Int32Array(entries.length);
+	let changed = true;
+	let iterations = 0;
+	while (changed && iterations < 250) {
+		changed = false;
+		iterations++;
+
+		for (let i = 0; i < entries.length; i++) {
+			assignments[i] = findNearestCenterIndex(entries[i].color, centers);
+		}
+
+		for (let i = 0; i < clusterCount; i++) {
+			let sumX = 0;
+			let sumY = 0;
+			let sumZ = 0;
+			let weight = 0;
+			for (let e = 0; e < entries.length; e++) {
+				if (assignments[e] !== i) continue;
+				const { color, count } = entries[e];
+				sumX += color[0] * count;
+				sumY += color[1] * count;
+				sumZ += color[2] * count;
+				weight += count;
+			}
+			if (weight === 0) {
+				// 空簇：把中心挪到离现有中心最远的颜色上，下一轮重新分配
+				centers[i] = findFarthestColor(entries, centers);
+				changed = true;
+				continue;
+			}
+			const newCenter: ColorVec3 = [
+				sumX / weight,
+				sumY / weight,
+				sumZ / weight,
+			];
+			if (!colorsEqual(newCenter, centers[i])) {
+				centers[i] = newCenter;
+				changed = true;
+			}
+		}
+	}
+
+	return centers;
+}
+
+/** 计算主题色，对应 C# 的 `KMeansPaletteGenerator.CreateThemeColor`。 */
+export function createThemeColor(
+	sourceColors: readonly ColorCount[],
+	ignoreWhite = false,
+	toLab = false,
+	random: RandomSource = createRandom(seedFromHistogram(sourceColors)),
+): ThemeColorResult {
+	let entries = [...sourceColors];
+	if (ignoreWhite && entries.length > 1) {
+		entries = filterOrFallback(entries, (entry) => isNotNearWhite(entry.color));
+	}
+	if (toLab) entries = toLabEntries(entries);
+	entries = groupColors(entries);
+
+	const centers = kMeansCluster(entries, 1, false, random);
+	const first = centers[0] ?? ([0, 0, 0] as ColorVec3);
+	const color = clampRgb(toLab ? labToRgb(first) : first);
+	return { color, colorIsDark: rgbLStarIsDark(color) };
+}
+
+/** 生成调色板，对应 C# 的 `KMeansPaletteGenerator.CreatePalette`。 */
+export function createKMeansPalette(
+	sourceColors: readonly ColorCount[],
+	clusterCount: number,
+	themeColor: ThemeColorResult,
+	ignoreWhite = false,
+	toLab = false,
+	useKMeansPP = false,
+	random: RandomSource = createRandom(seedFromHistogram(sourceColors)),
+): PaletteResult {
+	let effectiveIgnoreWhite = ignoreWhite;
+	let effectiveUseKMeansPP = useKMeansPP;
+	if (sourceColors.length === 1) {
+		effectiveIgnoreWhite = false;
+		effectiveUseKMeansPP = false;
+	}
+
+	const colorIsDark = themeColor.colorIsDark;
+	let entries = filterOrFallback(sourceColors, (entry) => {
+		if (colorIsDark) return paletteRgbLStarIsDark(entry.color);
+		if (!effectiveIgnoreWhite) return paletteRgbLStarIsLight(entry.color);
+		return paletteRgbLStarIsLight(entry.color) && isNotNearWhite(entry.color);
+	});
+	if (toLab) entries = toLabEntries(entries);
+	entries = groupColors(entries);
+
+	const centers = kMeansCluster(
+		entries,
+		clusterCount,
+		effectiveUseKMeansPP,
+		random,
+	);
+	const dominantColors = centers.map((center) =>
+		clampRgb(toLab ? labToRgb(center) : center),
+	);
+
+	const palette: ColorVec3[] = [];
+	for (let i = 0; i < clusterCount; i++) {
+		// 颜色不够时只能重复填充，原实现也是这么处理的
+		palette.push(
+			dominantColors.length > 0
+				? [...dominantColors[i % dominantColors.length]]
+				: [0, 0, 0],
+		);
+	}
+	return { palette, paletteIsDark: colorIsDark, themeColor };
+}

--- a/packages/core/src/bg-render/palette/octtree.ts
+++ b/packages/core/src/bg-render/palette/octtree.ts
@@ -5,6 +5,8 @@
  * 逐行移植自 Storyteller-Studios/Impressionist（MIT）的
  * `Impressionist/Implementations/OctTreePaletteGenerator.cs`，
  * 其本身衍生自 bacowan/cSharpColourQuantization。
+ *
+ * @see https://github.com/Storyteller-Studios/Impressionist/blob/master/Impressionist/Implementations/OctTreePaletteGenerator.cs
  */
 
 import {

--- a/packages/core/src/bg-render/palette/octtree.ts
+++ b/packages/core/src/bg-render/palette/octtree.ts
@@ -1,0 +1,292 @@
+/**
+ * @fileoverview
+ * 八叉树量化取色器。
+ *
+ * 逐行移植自 Storyteller-Studios/Impressionist（MIT）的
+ * `Impressionist/Implementations/OctTreePaletteGenerator.cs`，
+ * 其本身衍生自 bacowan/cSharpColourQuantization。
+ */
+
+import {
+	paletteRgbLStarIsDark,
+	paletteRgbLStarIsLight,
+} from "./color-utilities.ts";
+import { createThemeColor } from "./kmeans.ts";
+import type {
+	ColorCount,
+	ColorVec3,
+	PaletteResult,
+	ThemeColorResult,
+} from "./types.ts";
+
+const MAX_COLOR_DEPTH = 8;
+
+interface PaletteEntry {
+	color: ColorVec3;
+	sampleCount: number;
+}
+
+class OctreeNode {
+	readonly children: (OctreeNode | null)[] = [
+		null,
+		null,
+		null,
+		null,
+		null,
+		null,
+		null,
+		null,
+	];
+	childCount = 0;
+	leafNodeCount = 0;
+	sampleCount = 0;
+	private redSum = 0;
+	private greenSum = 0;
+	private blueSum = 0;
+
+	constructor(
+		private readonly owner: OctreePaletteQuantizer,
+		readonly parentNode: OctreeNode | null,
+		readonly indexInParent: number,
+	) {}
+
+	private get averageColor(): ColorVec3 {
+		if (this.sampleCount === 0) return [0, 0, 0];
+		return [
+			this.redSum / this.sampleCount,
+			this.greenSum / this.sampleCount,
+			this.blueSum / this.sampleCount,
+		];
+	}
+
+	addColor(
+		red: number,
+		green: number,
+		blue: number,
+		depth: number,
+		sampleCount: number,
+	): void {
+		this.sampleCount += sampleCount;
+		this.redSum += red * sampleCount;
+		this.greenSum += green * sampleCount;
+		this.blueSum += blue * sampleCount;
+
+		if (depth === MAX_COLOR_DEPTH) {
+			if (this.leafNodeCount === 0) this.leafNodeCount = 1;
+			return;
+		}
+
+		const bitShift = 7 - depth;
+		const childIndex =
+			(((red >> bitShift) & 1) << 2) |
+			(((green >> bitShift) & 1) << 1) |
+			((blue >> bitShift) & 1);
+		let childNode = this.children[childIndex];
+		if (!childNode) {
+			childNode = new OctreeNode(this.owner, this, childIndex);
+			this.children[childIndex] = childNode;
+			this.childCount++;
+			this.owner.registerNodeAtDepth(childNode, depth);
+		}
+
+		const previousLeafNodeCount = childNode.leafNodeCount;
+		childNode.addColor(red, green, blue, depth + 1, sampleCount);
+		this.leafNodeCount += childNode.leafNodeCount - previousLeafNodeCount;
+	}
+
+	collectPaletteColors(result: PaletteEntry[]): void {
+		if (this.leafNodeCount === 0) return;
+		if (this.childCount === 0) {
+			result.push({ color: this.averageColor, sampleCount: this.sampleCount });
+			return;
+		}
+		for (const child of this.children) child?.collectPaletteColors(result);
+	}
+
+	mergeChildrenIntoThisNode(): void {
+		if (this.childCount === 0 || this.leafNodeCount <= 1) return;
+
+		const previousLeafNodeCount = this.leafNodeCount;
+		this.children.fill(null);
+		this.childCount = 0;
+		this.leafNodeCount = this.sampleCount > 0 ? 1 : 0;
+
+		const leafReduction = previousLeafNodeCount - this.leafNodeCount;
+		let parentNode = this.parentNode;
+		while (parentNode) {
+			parentNode.leafNodeCount -= leafReduction;
+			parentNode = parentNode.parentNode;
+		}
+	}
+
+	/** 合并会把整棵子树摘掉，被摘掉的节点仍留在深度索引里，需要显式排除。 */
+	isAttachedToRoot(): boolean {
+		let currentNode: OctreeNode = this;
+		while (currentNode.parentNode) {
+			if (
+				currentNode.parentNode.children[currentNode.indexInParent] !==
+				currentNode
+			) {
+				return false;
+			}
+			currentNode = currentNode.parentNode;
+		}
+		return true;
+	}
+}
+
+class OctreePaletteQuantizer {
+	private readonly rootNode: OctreeNode = new OctreeNode(this, null, -1);
+	private readonly nodesByDepth: OctreeNode[][] = Array.from(
+		{ length: MAX_COLOR_DEPTH },
+		() => [],
+	);
+
+	registerNodeAtDepth(node: OctreeNode, depth: number): void {
+		this.nodesByDepth[depth].push(node);
+	}
+
+	addColor(color: ColorVec3, sampleCount: number): void {
+		if (sampleCount <= 0) return;
+		this.rootNode.addColor(
+			color[0] & 0xff,
+			color[1] & 0xff,
+			color[2] & 0xff,
+			0,
+			sampleCount,
+		);
+	}
+
+	getPalette(maxColorCount: number): ColorVec3[] {
+		if (maxColorCount <= 0 || this.rootNode.leafNodeCount === 0) return [];
+
+		const paletteColors: PaletteEntry[] = [];
+		this.rootNode.collectPaletteColors(paletteColors);
+
+		if (paletteColors.length <= maxColorCount) {
+			return paletteColors.map((entry) => entry.color);
+		}
+
+		paletteColors.sort((left, right) => {
+			const bySampleCount = right.sampleCount - left.sampleCount;
+			if (bySampleCount !== 0) return bySampleCount;
+			if (left.color[0] !== right.color[0]) {
+				return left.color[0] - right.color[0];
+			}
+			if (left.color[1] !== right.color[1]) {
+				return left.color[1] - right.color[1];
+			}
+			return left.color[2] - right.color[2];
+		});
+
+		return paletteColors
+			.slice(0, Math.min(maxColorCount, paletteColors.length))
+			.map((entry) => entry.color);
+	}
+
+	reduceToColorCount(targetColorCount: number): void {
+		if (targetColorCount <= 0) return;
+
+		let remainingLeafReduction = this.rootNode.leafNodeCount - targetColorCount;
+		if (remainingLeafReduction <= 0) return;
+
+		for (
+			let depth = MAX_COLOR_DEPTH - 2;
+			depth >= 0 && remainingLeafReduction > 0;
+			depth--
+		) {
+			const nodesAtDepth = this.nodesByDepth[depth];
+			nodesAtDepth.sort((left, right) => {
+				const byLeafCount = left.leafNodeCount - right.leafNodeCount;
+				if (byLeafCount !== 0) return byLeafCount;
+				return left.sampleCount - right.sampleCount;
+			});
+
+			for (
+				let i = 0;
+				i < nodesAtDepth.length && remainingLeafReduction > 0;
+				i++
+			) {
+				const candidate = nodesAtDepth[i];
+				if (candidate.childCount === 0) continue;
+				const leafReduction = candidate.leafNodeCount - 1;
+				if (leafReduction <= 0) continue;
+				if (leafReduction > remainingLeafReduction) continue;
+				remainingLeafReduction -= leafReduction;
+				candidate.mergeChildrenIntoThisNode();
+			}
+		}
+
+		while (this.rootNode.leafNodeCount > targetColorCount) {
+			const candidate = this.findBestMergeCandidate();
+			if (!candidate) break;
+			candidate.mergeChildrenIntoThisNode();
+		}
+	}
+
+	private findBestMergeCandidate(): OctreeNode | null {
+		let bestCandidate: OctreeNode | null = null;
+		let bestLeafReduction = Number.POSITIVE_INFINITY;
+		let bestSampleCount = Number.POSITIVE_INFINITY;
+
+		for (let depth = MAX_COLOR_DEPTH - 2; depth >= 0; depth--) {
+			for (const candidate of this.nodesByDepth[depth]) {
+				if (!candidate.isAttachedToRoot()) continue;
+				if (candidate.childCount === 0) continue;
+				const leafReduction = candidate.leafNodeCount - 1;
+				if (leafReduction <= 0) continue;
+				if (
+					leafReduction < bestLeafReduction ||
+					(leafReduction === bestLeafReduction &&
+						candidate.sampleCount < bestSampleCount)
+				) {
+					bestCandidate = candidate;
+					bestLeafReduction = leafReduction;
+					bestSampleCount = candidate.sampleCount;
+				}
+			}
+		}
+
+		return bestCandidate;
+	}
+}
+
+/** 生成调色板，对应 C# 的 `OctTreePaletteGenerator.CreatePalette`。 */
+export function createOctTreePalette(
+	sourceColors: readonly ColorCount[],
+	clusterCount: number,
+	themeColor: ThemeColorResult = createThemeColor(sourceColors, false, true),
+	ignoreWhite = false,
+): PaletteResult {
+	const quantizer = new OctreePaletteQuantizer();
+	const effectiveIgnoreWhite = sourceColors.length === 1 ? false : ignoreWhite;
+
+	const filteredEntries = sourceColors.filter((entry) => {
+		const [r, g, b] = entry.color;
+		if (effectiveIgnoreWhite && r > 250 && g > 250 && b > 250) return false;
+		return themeColor.colorIsDark
+			? paletteRgbLStarIsDark(entry.color)
+			: paletteRgbLStarIsLight(entry.color);
+	});
+	const entries = filteredEntries.length > 0 ? filteredEntries : sourceColors;
+
+	for (const entry of entries) quantizer.addColor(entry.color, entry.count);
+	quantizer.reduceToColorCount(clusterCount);
+	const quantizeResult = quantizer.getPalette(clusterCount);
+
+	let palette: ColorVec3[];
+	if (quantizeResult.length < clusterCount) {
+		palette = [];
+		for (let i = 0; i < clusterCount; i++) {
+			palette.push(
+				quantizeResult.length > 0
+					? [...quantizeResult[i % quantizeResult.length]]
+					: [0, 0, 0],
+			);
+		}
+	} else {
+		palette = quantizeResult;
+	}
+
+	return { palette, paletteIsDark: themeColor.colorIsDark, themeColor };
+}

--- a/packages/core/src/bg-render/palette/types.ts
+++ b/packages/core/src/bg-render/palette/types.ts
@@ -1,0 +1,45 @@
+/**
+ * @fileoverview
+ * 调色板取色器的公共类型。
+ *
+ * 移植自 Storyteller-Studios/Impressionist（MIT）：
+ * - `Impressionist/Abstractions/HSVColor.cs`
+ * - `Impressionist/Abstractions/PaletteResult.cs`
+ *
+ * 颜色一律用 `[x, y, z]` 三元组表示。在 RGB 空间时分量范围是 [0, 255]，
+ * 与 C# 原实现的 `Vector3` 约定保持一致；在 LAB 空间时则是 L/a/b 的原始取值。
+ */
+
+/** 一个颜色向量，语义随所处色彩空间而定。 */
+export type ColorVec3 = [number, number, number];
+
+/** HSV 颜色，H 取值 [0, 360)，S/V 取值 [0, 100]。 */
+export interface HSVColor {
+	h: number;
+	s: number;
+	v: number;
+}
+
+/** 直方图中的一项：一个颜色及其出现次数。 */
+export interface ColorCount {
+	color: ColorVec3;
+	count: number;
+}
+
+/** 主题色结果。 */
+export interface ThemeColorResult {
+	/** RGB 空间下的主题色，分量范围 [0, 255]。 */
+	color: ColorVec3;
+	/** 该主题色是否偏暗（L* <= 50）。 */
+	colorIsDark: boolean;
+}
+
+/** 调色板结果。 */
+export interface PaletteResult {
+	/** 调色板颜色，RGB 空间，分量范围 [0, 255]，长度恒等于请求的数量。 */
+	palette: ColorVec3[];
+	/** 该调色板整体是否偏暗。 */
+	paletteIsDark: boolean;
+	/** 生成调色板时顺带算出的主题色。 */
+	themeColor: ThemeColorResult;
+}

--- a/packages/core/src/bg-render/palette/types.ts
+++ b/packages/core/src/bg-render/palette/types.ts
@@ -8,6 +8,9 @@
  *
  * 颜色一律用 `[x, y, z]` 三元组表示。在 RGB 空间时分量范围是 [0, 255]，
  * 与 C# 原实现的 `Vector3` 约定保持一致；在 LAB 空间时则是 L/a/b 的原始取值。
+ *
+ * @see https://github.com/Storyteller-Studios/Impressionist/blob/master/Impressionist/Abstractions/HSVColor.cs
+ * @see https://github.com/Storyteller-Studios/Impressionist/blob/master/Impressionist/Abstractions/PaletteResult.cs
  */
 
 /** 一个颜色向量，语义随所处色彩空间而定。 */

--- a/packages/core/src/bg-render/support.ts
+++ b/packages/core/src/bg-render/support.ts
@@ -1,0 +1,41 @@
+/**
+ * @fileoverview
+ * 渲染器的运行环境能力探测。
+ *
+ * 渲染器的构造函数在拿不到所需上下文时会直接抛错，而 `BackgroundRender.new()`
+ * 只是 `new` 一下，没有回落余地。所以选择渲染器的一方（设置界面、从
+ * localStorage 恢复配置的地方）应当先问一句支不支持。
+ */
+
+let webgl1Support: boolean | undefined;
+let webgl2Support: boolean | undefined;
+
+function probe(contextId: "webgl" | "webgl2"): boolean {
+	try {
+		const canvas = document.createElement("canvas");
+		canvas.width = 1;
+		canvas.height = 1;
+		const gl = canvas.getContext(contextId) as
+			| WebGLRenderingContext
+			| WebGL2RenderingContext
+			| null;
+		if (!gl) return false;
+		// 探测用的上下文用完立刻释放，免得白占一个 WebGL 上下文名额
+		gl.getExtension("WEBGL_lose_context")?.loseContext();
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+/** 当前环境是否支持 WebGL1，结果只探测一次。 */
+export function isWebGL1Supported(): boolean {
+	if (webgl1Support === undefined) webgl1Support = probe("webgl");
+	return webgl1Support;
+}
+
+/** 当前环境是否支持 WebGL2，结果只探测一次。 */
+export function isWebGL2Supported(): boolean {
+	if (webgl2Support === undefined) webgl2Support = probe("webgl2");
+	return webgl2Support;
+}

--- a/packages/core/src/utils/canvas.ts
+++ b/packages/core/src/utils/canvas.ts
@@ -1,0 +1,15 @@
+/**
+ * 创建一个离屏画板，环境不支持 `OffscreenCanvas` 时回落到普通 canvas 元素。
+ */
+export function createOffscreenCanvas(
+	width: number,
+	height: number,
+): OffscreenCanvas | HTMLCanvasElement {
+	if (typeof OffscreenCanvas !== "undefined") {
+		return new OffscreenCanvas(width, height);
+	}
+	const canvas = document.createElement("canvas");
+	canvas.width = width;
+	canvas.height = height;
+	return canvas;
+}


### PR DESCRIPTION
## PR Summary

本 PR 是「Isolation 背景渲染器」系列堆叠 PR 的 **第 1 层（WebGL 基础设施与封面取色）**，由 #602 拆分而来。四层均直接基于 `main`、修改文件互不重叠，请按文末表格顺序审查合并。

### 本层改动

- 移植 Storyteller-Studios/Impressionist 的封面取色实现：K-Means、八叉树量化、主题色提取，以及 RGB / HSV / LAB 色彩空间工具（`bg-render/palette/*`）
- 新增 `GLProgram` WebGL 着色器封装，统一处理编译、链接、Attribute 获取、Uniform 缓存与资源释放
- 新增 WebGL1 / WebGL2 能力检测与离屏 Canvas 工具
- `MeshGradientRenderer` 改用 `GLProgram`，纯内部等价重构，行为不变

### 审查说明

- 本层不改变任何对外行为，mesh 重构为等价替换
- 第 2 层（Isolation 渲染器）依赖本层的 `GLProgram`、取色与能力检测

| 顺序 | PR | 内容 |
| --- | --- | --- |
| 1 | 本 PR | core：WebGL 基础设施与封面取色 |
| 2 | #604 | core：Isolation 渲染器 |
| 3 | #605 | react / react-full 集成 |
| 4 | #602 | playground 集成 |

