### PR TITLE
feat(react): 添加 Isolation 背景渲染器

### DIFF
--- a/.nx/version-plans/version-plan-1788625821495.md
+++ b/.nx/version-plans/version-plan-1788625821495.md
@@ -1,0 +1,6 @@
+---
+core-bundle: minor
+'@applemusic-like-lyrics/react-full': minor
+---
+
+feat(react-full): 添加 Isolation 背景渲染器

--- a/packages/core/src/bg-render/mesh-renderer/index.ts
+++ b/packages/core/src/bg-render/mesh-renderer/index.ts
@@ -16,6 +16,7 @@ import {
 import { BaseRenderer } from "../base.ts";
 import { GLProgram } from "../gl-program.ts";
 import { blurImage } from "../img.ts";
+import { isWebGL1Supported } from "../support.ts";
 import { generateControlPoints } from "./cp-generate.ts";
 import { CONTROL_POINT_PRESETS } from "./cp-presets.ts";
 import meshFragShader from "./mesh.frag.glsl?raw";
@@ -673,6 +674,13 @@ interface MeshState {
 }
 
 export class MeshGradientRenderer extends BaseRenderer {
+	/**
+	 * 当前环境是否支持此渲染器
+	 */
+	static isSupported(): boolean {
+		return isWebGL1Supported();
+	}
+
 	private gl: RenderingContext;
 	private contextLost = false;
 	private albumRequestId = 0;

--- a/packages/core/src/bg-render/pixi-renderer.ts
+++ b/packages/core/src/bg-render/pixi-renderer.ts
@@ -1,5 +1,5 @@
 import { Application } from "@pixi/app";
-import { Texture } from "@pixi/core";
+import { Texture, utils } from "@pixi/core";
 import { Container } from "@pixi/display";
 import { BlurFilter } from "@pixi/filter-blur";
 import { BulgePinchFilter } from "@pixi/filter-bulge-pinch";
@@ -17,6 +17,14 @@ class TimedContainer extends Container {
 }
 
 export class PixiRenderer extends BaseRenderer {
+	/**
+	 * 当前环境是否支持此渲染器
+	 */
+	static isSupported(): boolean {
+		// 询问 Pixi 是否支持而不是仓库内的 WebGL 检测，因为 Pixi 有额外的模板缓冲区要求
+		return utils.isWebGLSupported();
+	}
+
 	private app: Application;
 	private curContainer?: TimedContainer;
 	private staticMode = false;

--- a/packages/react-full/src/components/PrebuiltLyricPlayer/index.tsx
+++ b/packages/react-full/src/components/PrebuiltLyricPlayer/index.tsx
@@ -3,13 +3,15 @@
  * 已经部署好所有组件的歌词播放器组件，在正确设置所有的 Jotai 状态后可以开箱即用
  */
 
-import type { OptimizeLyricOptions } from "@applemusic-like-lyrics/core";
+import {
+	type BaseRenderer,
+	IsolationRenderer,
+	type OptimizeLyricOptions,
+} from "@applemusic-like-lyrics/core";
 import {
 	BackgroundRender,
 	LyricPlayer,
 	type LyricPlayerRef,
-	MeshGradientRenderer,
-	PixiRenderer,
 } from "@applemusic-like-lyrics/react";
 import structuredClone from "@ungap/structured-clone";
 import classNames from "classnames";
@@ -18,6 +20,7 @@ import { atom, useAtom, useAtomValue, useSetAtom } from "jotai";
 import {
 	type FC,
 	type HTMLProps,
+	useCallback,
 	useEffect,
 	useLayoutEffect,
 	useMemo,
@@ -72,6 +75,7 @@ import {
 	enableLyricTranslationLineAtom,
 	hideLyricViewAtom,
 	isLyricPageOpenedAtom,
+	isolationRendererOptionsAtom,
 	LyricSizePreset,
 	lyricBackgroundFPSAtom,
 	lyricBackgroundRendererAtom,
@@ -85,6 +89,7 @@ import {
 	lyricWordFadeWidthAtom,
 	PlayerControlsType,
 	playerControlsTypeAtom,
+	resolveBackgroundRenderer,
 	showBottomControlAtom,
 	showMusicAlbumAtom,
 	showMusicArtistsAtom,
@@ -537,6 +542,15 @@ export const PrebuiltLyricPlayer: FC<PrebuiltLyricPlayerProps> = ({
 	const coverElRef = useRef<HTMLDivElement>(null);
 	const [layoutEl, setLayoutEl] = useState<HTMLDivElement | null>(null);
 	const backgroundRenderer = useAtomValue(lyricBackgroundRendererAtom);
+	const isolationRendererOptions = useAtomValue(isolationRendererOptionsAtom);
+	const configureBackgroundRenderer = useCallback(
+		(renderer: BaseRenderer) => {
+			if (renderer instanceof IsolationRenderer) {
+				renderer.setOptions(isolationRendererOptions);
+			}
+		},
+		[isolationRendererOptions],
+	);
 	const showBottomControl = useAtomValue(showBottomControlAtom);
 
 	const cssBackgroundProperty = useAtomValue(cssBackgroundPropertyAtom);
@@ -620,12 +634,11 @@ export const PrebuiltLyricPlayer: FC<PrebuiltLyricPlayerProps> = ({
 							fps={lyricBackgroundFPS}
 							renderer={
 								typeof backgroundRenderer.renderer === "string"
-									? backgroundRenderer.renderer === "pixi"
-										? PixiRenderer
-										: MeshGradientRenderer
+									? resolveBackgroundRenderer(backgroundRenderer.renderer)
 									: backgroundRenderer.renderer
 							}
 							staticMode={lyricBackgroundStaticMode || !isLyricPageOpened}
+							configureRenderer={configureBackgroundRenderer}
 							style={{
 								zIndex: -1,
 							}}

--- a/packages/react-full/src/components/PrebuiltLyricPlayer/index.tsx
+++ b/packages/react-full/src/components/PrebuiltLyricPlayer/index.tsx
@@ -66,7 +66,9 @@ import {
 	onSeekPositionAtom,
 } from "../../states/callbacks";
 import {
+	CSS_BACKGROUND_RENDERER_ID,
 	cssBackgroundPropertyAtom,
+	DEFAULT_BACKGROUND_RENDERER_ID,
 	enableLyricLineBlurEffectAtom,
 	enableLyricLineScaleEffectAtom,
 	enableLyricLineSpringAnimationAtom,
@@ -542,6 +544,18 @@ export const PrebuiltLyricPlayer: FC<PrebuiltLyricPlayerProps> = ({
 	const coverElRef = useRef<HTMLDivElement>(null);
 	const [layoutEl, setLayoutEl] = useState<HTMLDivElement | null>(null);
 	const backgroundRenderer = useAtomValue(lyricBackgroundRendererAtom);
+	// 配置里存的可能是字符串标识，也可能是调用方直接塞进来的渲染器类。字符串一律
+	// 过一遍支持性检查，解析成 css-bg 时说明当前环境没有能用的渲染器，改走下面的
+	// CSS 背景分支
+	const resolvedBackgroundRenderer = useMemo(() => {
+		const configured = backgroundRenderer.renderer;
+		if (typeof configured === "string") {
+			return resolveBackgroundRenderer(configured);
+		}
+		return (
+			configured ?? resolveBackgroundRenderer(DEFAULT_BACKGROUND_RENDERER_ID)
+		);
+	}, [backgroundRenderer.renderer]);
 	const isolationRendererOptions = useAtomValue(isolationRendererOptionsAtom);
 	const configureBackgroundRenderer = useCallback(
 		(renderer: BaseRenderer) => {
@@ -612,8 +626,7 @@ export const PrebuiltLyricPlayer: FC<PrebuiltLyricPlayerProps> = ({
 					/>
 				}
 				backgroundSlot={
-					typeof backgroundRenderer.renderer === "string" &&
-					backgroundRenderer.renderer === "css-bg" ? (
+					resolvedBackgroundRenderer === CSS_BACKGROUND_RENDERER_ID ? (
 						<div
 							style={{
 								zIndex: -1,
@@ -632,11 +645,7 @@ export const PrebuiltLyricPlayer: FC<PrebuiltLyricPlayerProps> = ({
 							lowFreqVolume={lowFreqVolume}
 							renderScale={lyricBackgroundRenderScale}
 							fps={lyricBackgroundFPS}
-							renderer={
-								typeof backgroundRenderer.renderer === "string"
-									? resolveBackgroundRenderer(backgroundRenderer.renderer)
-									: backgroundRenderer.renderer
-							}
+							renderer={resolvedBackgroundRenderer}
 							staticMode={lyricBackgroundStaticMode || !isLyricPageOpened}
 							configureRenderer={configureBackgroundRenderer}
 							style={{

--- a/packages/react-full/src/states/configAtoms.ts
+++ b/packages/react-full/src/states/configAtoms.ts
@@ -331,27 +331,30 @@ export interface BackgroundRendererEntry {
 	readonly renderer: {
 		new (canvas: HTMLCanvasElement): BaseRenderer;
 	};
-	/** 当前环境是否支持，不支持时会回落到网格渐变渲染器。 */
+	/**
+	 * 当前环境是否支持，不支持时会按 {@link resolveBackgroundRenderer} 的顺序回落
+	 */
 	readonly isSupported: () => boolean;
 }
+
+export const CSS_BACKGROUND_RENDERER_ID = "css-bg";
+export const DEFAULT_BACKGROUND_RENDERER_ID = "mesh";
 
 /**
  * 所有可选的背景渲染器。
  *
- * 这里是字符串标识与渲染器类之间唯一的映射表，持久化配置与实际装配都从这里
- * 取，新增渲染器只需要往这张表里加一项。`"css-bg"` 不在表内，它不是渲染器，
- * 而是直接用 CSS 背景的特例。
+ * `"css-bg"` 不在表内，因为它不是渲染器，而是固定的纯色 CSS 背景
  */
 export const BACKGROUND_RENDERERS: Readonly<
 	Record<string, BackgroundRendererEntry>
 > = {
 	mesh: {
 		renderer: MeshGradientRenderer,
-		isSupported: () => true,
+		isSupported: () => MeshGradientRenderer.isSupported(),
 	},
 	pixi: {
 		renderer: PixiRenderer,
-		isSupported: () => true,
+		isSupported: () => PixiRenderer.isSupported(),
 	},
 	isolation: {
 		renderer: IsolationRenderer,
@@ -364,25 +367,35 @@ export const LYRIC_BACKGROUND_RENDERER_STORAGE_KEY =
 	"amll-react-full.lyricBackgroundRenderer";
 
 /**
- * 把字符串标识解析成渲染器类。
+ * {@link resolveBackgroundRenderer} 的结果：可以直接使用的渲染器类，或
+ * {@link CSS_BACKGROUND_RENDERER_ID} 表示不需要加载背景渲染器
+ */
+export type ResolvedBackgroundRenderer =
+	| BackgroundRendererEntry["renderer"]
+	| typeof CSS_BACKGROUND_RENDERER_ID;
+
+/**
+ * 把字符串标识解析成渲染器
  *
- * 未知的标识、以及当前环境不支持的渲染器，都会回落到网格渐变渲染器。
+ * 如果传入的渲染器标识在当前环境不支持，则会依次回退到 Mesh 渲染器和 CSS 背景
  */
 export const resolveBackgroundRenderer = (
 	id: string,
-): BackgroundRenderProps["renderer"] => {
+): ResolvedBackgroundRenderer => {
+	if (id === CSS_BACKGROUND_RENDERER_ID) return CSS_BACKGROUND_RENDERER_ID;
 	const entry = BACKGROUND_RENDERERS[id];
 	if (entry?.isSupported()) return entry.renderer;
-	return MeshGradientRenderer;
+	const fallback = BACKGROUND_RENDERERS[DEFAULT_BACKGROUND_RENDERER_ID];
+	if (fallback?.isSupported()) return fallback.renderer;
+	return CSS_BACKGROUND_RENDERER_ID;
 };
 
-const getInitialBackgroundRenderer = (): LyricBackgroundRenderer => {
-	const savedRenderer = localStorage.getItem(
-		LYRIC_BACKGROUND_RENDERER_STORAGE_KEY,
-	);
-	if (savedRenderer === "css-bg") return { renderer: "css-bg" };
-	return { renderer: resolveBackgroundRenderer(savedRenderer ?? "mesh") };
-};
+const getInitialBackgroundRenderer = (): LyricBackgroundRenderer => ({
+	renderer: resolveBackgroundRenderer(
+		localStorage.getItem(LYRIC_BACKGROUND_RENDERER_STORAGE_KEY) ??
+			DEFAULT_BACKGROUND_RENDERER_ID,
+	),
+});
 
 /**
  * 配置所使用的歌词背景渲染器

--- a/packages/react-full/src/states/configAtoms.ts
+++ b/packages/react-full/src/states/configAtoms.ts
@@ -1,5 +1,8 @@
 import {
+	type BaseRenderer,
 	DomLyricPlayer,
+	IsolationRenderer,
+	type IsolationRendererOptions,
 	type LyricPlayerBase,
 	MeshGradientRenderer,
 	PixiRenderer,
@@ -322,18 +325,63 @@ export type LyricBackgroundRenderer = {
 	renderer?: BackgroundRenderProps["renderer"] | string;
 };
 
+/** 一个可选背景渲染器的注册项。 */
+export interface BackgroundRendererEntry {
+	/** 渲染器类。 */
+	readonly renderer: {
+		new (canvas: HTMLCanvasElement): BaseRenderer;
+	};
+	/** 当前环境是否支持，不支持时会回落到网格渐变渲染器。 */
+	readonly isSupported: () => boolean;
+}
+
+/**
+ * 所有可选的背景渲染器。
+ *
+ * 这里是字符串标识与渲染器类之间唯一的映射表，持久化配置与实际装配都从这里
+ * 取，新增渲染器只需要往这张表里加一项。`"css-bg"` 不在表内，它不是渲染器，
+ * 而是直接用 CSS 背景的特例。
+ */
+export const BACKGROUND_RENDERERS: Readonly<
+	Record<string, BackgroundRendererEntry>
+> = {
+	mesh: {
+		renderer: MeshGradientRenderer,
+		isSupported: () => true,
+	},
+	pixi: {
+		renderer: PixiRenderer,
+		isSupported: () => true,
+	},
+	isolation: {
+		renderer: IsolationRenderer,
+		isSupported: () => IsolationRenderer.isSupported(),
+	},
+};
+
+/** 背景渲染器配置在 localStorage 中的键名。 */
+export const LYRIC_BACKGROUND_RENDERER_STORAGE_KEY =
+	"amll-react-full.lyricBackgroundRenderer";
+
+/**
+ * 把字符串标识解析成渲染器类。
+ *
+ * 未知的标识、以及当前环境不支持的渲染器，都会回落到网格渐变渲染器。
+ */
+export const resolveBackgroundRenderer = (
+	id: string,
+): BackgroundRenderProps["renderer"] => {
+	const entry = BACKGROUND_RENDERERS[id];
+	if (entry?.isSupported()) return entry.renderer;
+	return MeshGradientRenderer;
+};
+
 const getInitialBackgroundRenderer = (): LyricBackgroundRenderer => {
 	const savedRenderer = localStorage.getItem(
-		"amll-react-full.lyricBackgroundRenderer",
+		LYRIC_BACKGROUND_RENDERER_STORAGE_KEY,
 	);
-	switch (savedRenderer) {
-		case "pixi":
-			return { renderer: PixiRenderer };
-		case "css-bg":
-			return { renderer: "css-bg" };
-		default:
-			return { renderer: MeshGradientRenderer };
-	}
+	if (savedRenderer === "css-bg") return { renderer: "css-bg" };
+	return { renderer: resolveBackgroundRenderer(savedRenderer ?? "mesh") };
 };
 
 /**
@@ -341,6 +389,24 @@ const getInitialBackgroundRenderer = (): LyricBackgroundRenderer => {
  */
 export const lyricBackgroundRendererAtom: PrimitiveAtom<LyricBackgroundRenderer> =
 	atom<LyricBackgroundRenderer>(getInitialBackgroundRenderer());
+
+/**
+ * Isolation 背景渲染器的专属选项
+ *
+ * 仅在背景渲染器为 Isolation 时生效
+ */
+export const isolationRendererOptionsAtom: WritableAtom<
+	IsolationRendererOptions,
+	[
+		| IsolationRendererOptions
+		| ((prev: IsolationRendererOptions) => IsolationRendererOptions)
+		| typeof RESET,
+	],
+	void
+> = atomWithStorage<IsolationRendererOptions>(
+	"amll-react-full.isolationRendererOptions",
+	{ ...IsolationRenderer.defaultOptions },
+);
 
 /**
  * 当背景渲染器设置为纯色或CSS背景时，使用此值

--- a/packages/react/src/bg-render.tsx
+++ b/packages/react/src/bg-render.tsx
@@ -70,12 +70,18 @@ export interface BackgroundRenderProps {
 	 */
 	staticMode?: boolean;
 	/**
-	 * 设置渲染器，如果为 `undefined` 则默认为 `PixiRenderer`
+	 * 设置渲染器，如果为 `undefined` 则默认为 `MeshGradientRenderer`
 	 * 默认渲染器有可能会随着版本更新而更换
 	 */
 	renderer?: {
 		new (...args: ConstructorParameters<typeof BaseRenderer>): BaseRenderer;
 	};
+	/**
+	 * 配置当前渲染器实例。
+	 *
+	 * 渲染器创建或回调变化后调用，可用于下发特定渲染器才支持的选项。
+	 */
+	configureRenderer?: (renderer: BaseRenderer) => void;
 }
 
 /**
@@ -114,40 +120,54 @@ export const BackgroundRender: ForwardRefExoticComponent<
 			lowFreqVolume,
 			hasLyric,
 			renderer,
+			configureRenderer,
 			style,
 			...props
 		},
 		ref,
 	) => {
-		const coreBGRenderRef = useRef<AbstractBaseRenderer>(null);
+		const coreBGRenderRef = useRef<CoreBackgroundRender<BaseRenderer>>(null);
 		const wrapperRef = useRef<HTMLDivElement>(null);
-		const lastRendererRef = useRef<{
-			new (canvas: HTMLCanvasElement): BaseRenderer;
-		}>(null);
+		const configureRendererRef = useRef(configureRenderer);
+		configureRendererRef.current = configureRenderer;
+		const rendererPropsRef = useRef({
+			album,
+			albumIsVideo,
+			fps,
+			playing,
+			flowSpeed,
+			renderScale,
+			staticMode,
+			lowFreqVolume,
+			hasLyric,
+		});
+		rendererPropsRef.current = {
+			album,
+			albumIsVideo,
+			fps,
+			playing,
+			flowSpeed,
+			renderScale,
+			staticMode,
+			lowFreqVolume,
+			hasLyric,
+		};
 		const curRenderer = renderer ?? MeshGradientRenderer;
 
 		useEffect(() => {
-			if (
-				lastRendererRef.current !== curRenderer ||
-				coreBGRenderRef.current === undefined
-			) {
-				lastRendererRef.current = curRenderer;
-				coreBGRenderRef.current?.dispose();
-				coreBGRenderRef.current = CoreBackgroundRender.new(curRenderer);
-			}
-		}, [curRenderer]);
+			const rendererInstance = coreBGRenderRef.current?.getRenderer();
+			if (rendererInstance) configureRenderer?.(rendererInstance);
+		}, [configureRenderer]);
 
 		useEffect(() => {
-			if (curRenderer && album)
-				coreBGRenderRef.current?.setAlbum(album, albumIsVideo);
-		}, [curRenderer, album, albumIsVideo]);
+			if (album) coreBGRenderRef.current?.setAlbum(album, albumIsVideo);
+		}, [album, albumIsVideo]);
 
 		useEffect(() => {
-			if (curRenderer && fps) coreBGRenderRef.current?.setFPS(fps);
-		}, [curRenderer, fps]);
+			if (fps !== undefined) coreBGRenderRef.current?.setFPS(fps);
+		}, [fps]);
 
 		useEffect(() => {
-			if (!curRenderer) return;
 			if (playing === undefined) {
 				coreBGRenderRef.current?.resume();
 			} else if (playing) {
@@ -155,54 +175,89 @@ export const BackgroundRender: ForwardRefExoticComponent<
 			} else {
 				coreBGRenderRef.current?.pause();
 			}
-		}, [curRenderer, playing]);
+		}, [playing]);
 
 		useEffect(() => {
-			if (!curRenderer) return;
-			if (flowSpeed) coreBGRenderRef.current?.setFlowSpeed(flowSpeed);
-		}, [curRenderer, flowSpeed]);
-
-		useEffect(() => {
-			if (!curRenderer) return;
-			coreBGRenderRef.current?.setStaticMode(staticMode ?? false);
-		}, [curRenderer, staticMode]);
-
-		useEffect(() => {
-			if (curRenderer && renderScale)
-				coreBGRenderRef.current?.setRenderScale(renderScale ?? 0.5);
-		}, [curRenderer, renderScale]);
-
-		useEffect(() => {
-			if (curRenderer && lowFreqVolume)
-				coreBGRenderRef.current?.setLowFreqVolume(lowFreqVolume ?? 1.0);
-		}, [curRenderer, lowFreqVolume]);
-
-		useEffect(() => {
-			if (curRenderer && hasLyric !== undefined)
-				coreBGRenderRef.current?.setHasLyric(hasLyric ?? true);
-		}, [curRenderer, hasLyric]);
-
-		// biome-ignore lint/correctness/useExhaustiveDependencies: coreBGRenderRef.current
-		useEffect(() => {
-			if (coreBGRenderRef.current) {
-				const el = coreBGRenderRef.current.getElement();
-				el.style.width = "100%";
-				el.style.height = "100%";
-				el.style.minHeight = "0";
-				el.style.minWidth = "0";
-				el.style.overflow = "hidden";
-				wrapperRef.current?.appendChild(el);
+			if (flowSpeed !== undefined) {
+				coreBGRenderRef.current?.setFlowSpeed(flowSpeed);
 			}
-		}, [coreBGRenderRef.current]);
+		}, [flowSpeed]);
 
-		// biome-ignore lint/correctness/useExhaustiveDependencies: wrapperRef.current, coreBGRenderRef.current
+		useEffect(() => {
+			coreBGRenderRef.current?.setStaticMode(staticMode ?? false);
+		}, [staticMode]);
+
+		useEffect(() => {
+			if (renderScale !== undefined) {
+				coreBGRenderRef.current?.setRenderScale(renderScale);
+			}
+		}, [renderScale]);
+
+		useEffect(() => {
+			if (lowFreqVolume !== undefined) {
+				coreBGRenderRef.current?.setLowFreqVolume(lowFreqVolume);
+			}
+		}, [lowFreqVolume]);
+
+		useEffect(() => {
+			if (hasLyric !== undefined) {
+				coreBGRenderRef.current?.setHasLyric(hasLyric);
+			}
+		}, [hasLyric]);
+
+		useEffect(() => {
+			const backgroundRender = CoreBackgroundRender.new(curRenderer);
+			coreBGRenderRef.current = backgroundRender;
+			configureRendererRef.current?.(backgroundRender.getRenderer());
+
+			const current = rendererPropsRef.current;
+			if (current.album) {
+				backgroundRender.setAlbum(current.album, current.albumIsVideo);
+			}
+			if (current.fps !== undefined) backgroundRender.setFPS(current.fps);
+			if (current.flowSpeed !== undefined) {
+				backgroundRender.setFlowSpeed(current.flowSpeed);
+			}
+			backgroundRender.setStaticMode(current.staticMode ?? false);
+			if (current.renderScale !== undefined) {
+				backgroundRender.setRenderScale(current.renderScale);
+			}
+			if (current.lowFreqVolume !== undefined) {
+				backgroundRender.setLowFreqVolume(current.lowFreqVolume);
+			}
+			if (current.hasLyric !== undefined) {
+				backgroundRender.setHasLyric(current.hasLyric);
+			}
+			if (current.playing === false) backgroundRender.pause();
+			else backgroundRender.resume();
+
+			const element = backgroundRender.getElement();
+			element.style.width = "100%";
+			element.style.height = "100%";
+			element.style.minHeight = "0";
+			element.style.minWidth = "0";
+			element.style.overflow = "hidden";
+			wrapperRef.current?.appendChild(element);
+
+			return () => {
+				backgroundRender.dispose();
+				if (coreBGRenderRef.current === backgroundRender) {
+					coreBGRenderRef.current = null;
+				}
+			};
+		}, [curRenderer]);
+
 		useImperativeHandle(
 			ref,
 			() => ({
-				wrapperEl: wrapperRef.current,
-				bgRender: coreBGRenderRef.current as AbstractBaseRenderer,
+				get wrapperEl() {
+					return wrapperRef.current;
+				},
+				get bgRender() {
+					return coreBGRenderRef.current ?? undefined;
+				},
 			}),
-			[wrapperRef.current, coreBGRenderRef.current],
+			[],
 		);
 
 		return (


### PR DESCRIPTION
## PR Summary

本 PR 是「Isolation 背景渲染器」系列堆叠 PR 的 **第 3 层（react / react-full 集成）**，依赖 #603 与 #604。四层均直接基于 `main`、修改文件互不重叠，请按文末表格顺序审查合并。

### 本层改动

- react：重构 `BackgroundRender` 的实例管理与配置流程，新增 `configureRenderer` 回调；渲染器切换后正确重放当前专辑、FPS、播放状态、流速、缩放、静态模式与专属配置
- react-full：新增背景渲染器注册表与解析机制（`BACKGROUND_RENDERERS` / `resolveBackgroundRenderer`），支持 Isolation 配置持久化，WebGL 不可用时自动回退至 Mesh Gradient
- `PrebuiltLyricPlayer` 接入 Isolation 专属配置（取色算法 / Light Wave / Dithering）

### 审查说明

- 依赖 #603、#604，合并顺序为 #603 → #604 → 本 PR
- 本分支直接基于 `main`（fork 无法选择上层 PR 作为 base），合并前请确保前两层已合入

| 顺序 | PR | 内容 |
| --- | --- | --- |
| 1 | #603 | core：WebGL 基础设施与封面取色 |
| 2 | #604 | core：Isolation 渲染器 |
| 3 | 本 PR | react / react-full 集成 |
| 4 | #602 | playground 集成 |
